### PR TITLE
Updates in examples with removal of non-used elements

### DIFF
--- a/implementation/index.md
+++ b/implementation/index.md
@@ -281,7 +281,7 @@ The following elements describe the core characteristics of the referenced metad
 Example of the METS `<dmdSec>` element using `<mdRef>`:
 ```xml
 <mets:dmdSec ID="uuid-906F4F12-BA52-4779-AE2C-178F9206111F" CREATED="2018-04-24T14:37:49.609+01:00">
-    <mets:mdRef LOCTYPE="URL" MDTYPE="EAD" MDTYPEVERSION="2002" xlink:type="simple"  xlink:href="metadata/descriptive/ead2002.xml" SIZE="903" CREATED="2018-04-24T14:37:49.609+01:00" CHECKSUM="F24263BF09994749F335E1664DCE0086DB6DCA323FDB6996938BCD28EA9E8153" CHECKSUMTYPE="SHA-256"/>
+    <mets:mdRef LOCTYPE="URL" MDTYPE="EAD" xlink:type="simple"  xlink:href="metadata/descriptive/ead2002.xml" mimetype="application/xml" SIZE="903" CREATED="2018-04-24T14:37:49.609+01:00" CHECKSUM="F24263BF09994749F335E1664DCE0086DB6DCA323FDB6996938BCD28EA9E8153" CHECKSUMTYPE="SHA-256"/>
 </mets:dmdSec>
 ```
 
@@ -371,7 +371,7 @@ The specific requirements for elements, sub-elements and attributes are listed i
 
 Example of the fileSec element:
 ```xml
-<mets:fileSec ID="uuid-CA580D47-8C8B-4E91-ABD5-142EBBE15B84">
+<mets:fileSec>
     <mets:fileGrp ID="uuid-5811D494-6045-4741-924C-A1CFA340C276" USE="Common Specification files root">
         <mets:fileGrp ID="uuid-075D87BB-FAFA-4718-A7E7-FFF5FE2FF210" USE="metadata">
             <mets:fileGrp ID="uuid-6290B550-E965-41CC-9DAF-BA0AA777C320" USE="descriptive"/>


### PR DESCRIPTION
Removed mdtype version attribute from the mdref since its not used in CS IP and likewise with the ID attribute on the fileSec.