### PR TITLE
Fix OTHERCONTENTTYPESPECIFICATION

### DIFF
--- a/schema/DILCISExtensionMETS.xsd
+++ b/schema/DILCISExtensionMETS.xsd
@@ -16,7 +16,7 @@
             </xs:restriction>
         </xs:simpleType>
     </xs:attribute>
-    <xs:attribute name="OTHERCONTENTTYPESPECIFICATION" type="xs:string"/>
+    <xs:attribute name="OTHERCONTENTINFORMATIONTYPE" type="xs:string"/>
     <xs:attribute name="OAISPACKAGETYPE">
         <xs:simpleType>
             <xs:restriction base="xs:string">

--- a/schema/index.md
+++ b/schema/index.md
@@ -9,10 +9,10 @@ CSIP Associated Schema Files
 - [DILCIS METS Extensions](./DILCISExtensionMETS.xsd)
   Enumerated restrictions and types for attributes:
   + `CONTENTINFORMATIONTYPE`
-  + `OTHERCONTENTTYPESPECIFICATION`
+  + `OTHERCONTENTINFORMATIONTYPE`
   + `OAISPACKAGETYPE`
   + `NOTETYPE`
-- [RELAX grammer for describing vocabularies](DILCISVocabularies.rng)
+- [RELAX grammar for describing vocabularies](DILCISVocabularies.rng)
   Used for vocabulary definitions below.
 - [DILCIS IP Vocabulary Definitions](./DILCISVocabulariesIP.xml)
   Fixed vocabularies for:


### PR DESCRIPTION
Replace `OTHERCONTENTTYPESPECIFICATION` with `OTHERCONTENTINFORMATIONTYPE`, as defined in CSIP5 `mets/@csip:OTHERCONTENTINFORMATIONTYPE` and CSIP63 `fileSec/fileGrp/@csip:OTHERCONTENTINFORMATIONTYPE`.