### PR TITLE
REV - Improved Profile xPaths

### DIFF
--- a/profile/CSIP.xml
+++ b/profile/CSIP.xml
@@ -5,14 +5,14 @@
     xmlns:mets="http://www.loc.gov/METS/"
     xmlns:csip="https://dilcis.eu/XML/METS/CSIPExtensionMETS"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd" STATUS="provisional" REGISTRATION="unregistered" ID="V2.0.0-DRAFT">
+    xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd" STATUS="provisional" REGISTRATION="unregistered" ID="V2.0.0-RC">
     <URI LOCTYPE="URL" ASSIGNEDBY="local">https://earkcsip.dilcis.eu/profile/CSIP.xml</URI>
     <title>E-ARK CSIP METS Profile 2.0</title>
     <abstract>This base profile describes the Common Specification for Information Packages (CSIP) and the implementation of METS for packaging OAIS conformant Information Packages. The profile is accompanied with a textuall document explaning the details of use of this profile.
         This will enable repository interoperability and assist in the management of the preservation of digital content.
         This profile is a base profile which is extended with E-ARK implementation of SIP, AIP and DIP.
     The profile can be used as is, but it is recommended that the supplied extending implementation are used. Alternatively, an own extension fulfilling the extending needs of the implementer can be created.</abstract>
-    <date>2018-11-28T15:00:00</date>
+    <date>2018-05-15T01:00:00</date>
     <contact>
         <institution>DILCIS Board</institution>
         <address>http://dilcis.eu/</address>
@@ -50,7 +50,7 @@
             <name>Content information type specification</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyContentInformationType.xml</URI>
-            <context>Used in @csip:CONTENTINFORMATIONTYPE</context>
+            <context>Values for `@csip:CONTENTINFORMATIONTYPE`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Lists the names of specific E-ARK content information type specifications supported or maintained in this METS profile.</p>
             </description>
@@ -59,7 +59,7 @@
             <name>Content Category</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyContentCategory.xml</URI>
-            <context>Used in mets/@type</context>
+            <context>Values for `mets/@type`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Declares the categorical classification of package content.</p>
             </description>
@@ -68,7 +68,7 @@
             <name>OAIS Package type</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyOAISPackageType.xml</URI>
-            <context>Used in @csip:OAISPACKAGETYPE</context>
+            <context>Values for `@csip:OAISPACKAGETYPE`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Describes the OAIS type the package belongs to in the OAIS reference model.</p>
             </description>
@@ -77,7 +77,7 @@
             <name>Note type</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyNoteType.xml</URI>
-            <context>Used in @csip:NOTETYPE</context>
+            <context>Values for `@csip:NOTETYPE`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Provides values for the type of a note for an agent.</p>
             </description>
@@ -86,7 +86,7 @@
             <name>Other agent type</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyAgentOtherType.xml</URI>
-            <context>Used in metsHdr/agent/@OTHERTYPE</context>
+            <context>Values for `metsHdr/agent/@OTHERTYPE`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Describes the other agent types supported by the profile.</p>
             </description>
@@ -95,7 +95,7 @@
             <name>Identifier type</name>
             <maintenance_agency>Library of Congress</maintenance_agency>
             <URI>http://id.loc.gov/vocabulary/identifiers.html</URI>
-            <context>Used in metsHdr/altRecordID/@TYPE</context>
+            <context>Values for `metsHdr/altRecordID/@TYPE`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Describes the type of the identifier.</p>
             </description>
@@ -104,7 +104,7 @@
             <name>dmdSec status</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyStatus.xml</URI>
-            <context>Used in dmdSec/@STATUS</context>
+            <context>Values for `dmdSec/@STATUS`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Describes the status of the descriptive metadata section (dmdSec) which is supported by the profile.</p>
             </description>
@@ -113,7 +113,7 @@
             <name>IANA media types</name>
             <maintenance_agency>IANAs</maintenance_agency>
                 <URI>https://www.iana.org/assignments/media-types/media-types.xhtml</URI>
-            <context>Used in @MIMETYPE</context>
+            <context>Values for `@MIMETYPE`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Valid values for the mime types of referenced files.</p>
             </description>
@@ -122,9 +122,9 @@
             <name>File group names</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyFileGrpAndStructMapDivisionLabel.xml</URI>
-            <context>Used in fileGrp/@USE</context>
+            <context>Values for `fileGrp/@USE`</context>
             <description>
-                <p xmlns="http://www.w3.org/1999/xhtml">Describes the uses of the file group (fileGrp) that are supported by the profile.</p>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the uses of the file group `&lt;fileGrp&gt;` that are supported by the profile.</p>
                 <p xmlns="http://www.w3.org/1999/xhtml">Own names should be placed in an own extending vocabulary.</p>
             </description>
         </vocabulary>
@@ -132,9 +132,9 @@
             <name>Structural map typing</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyStructMapType.xml</URI>
-            <context>Used in structMap/@TYPE</context>
+            <context>Values for `structMap/@TYPE`</context>
             <description>
-                <p xmlns="http://www.w3.org/1999/xhtml">Describes the type of the structural map (structMap) that is supported by the profile.</p>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the type of the structural map `&lt;structMap&gt;` that is supported by the profile.</p>
                 <p xmlns="http://www.w3.org/1999/xhtml">Own types should be placed in an own extending vocabulary.</p>
             </description>
         </vocabulary>
@@ -142,7 +142,7 @@
             <name>Structural map label</name>
             <maintenance_agency>DILCIS Board</maintenance_agency>
             <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyStructMapLabel.xml</URI>
-            <context>Used in structMap/@LABEL</context>
+            <context>Values for `structMap/@LABEL`</context>
             <description>
                 <p xmlns="http://www.w3.org/1999/xhtml">Describes the label of the structural map that is supported by the profile.</p>
                 <p xmlns="http://www.w3.org/1999/xhtml">Own labels should be placed in an own extending vocabulary.</p>
@@ -154,7 +154,7 @@
             <requirement ID="CSIP1" REQLEVEL="MUST" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                 <description>
                     <head>Package Identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The @OBJID attribute is mandatory, its value is a string identifier for the METS document. For the package METS document, this should be the name/ID of the package, i.e. the name of the package root folder.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `mets/@OBJID` attribute is mandatory, its value is a string identifier for the METS document. For the package METS document, this should be the name/ID of the package, i.e. the name of the package root folder.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">For a representation level METS document this value records the name/ID of the representation, i.e. the name of the top-level representation folder.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
                         <dt>METS XPath</dt><dd>mets/@OBJID</dd>
@@ -165,7 +165,7 @@
             <requirement ID="CSIP2" REQLEVEL="MUST" RELATEDMAT="VocabularyContentCategory" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                 <description>
                     <head>Content Category</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The @TYPE attribute MUST be used to declare the category of the content held in the package, e.g. book, journal, stereograph, video, etc.. Legal values are defined in a fixed vocabulary. When the content category used falls outside of the defined vocabulary the @TYPE value must be set to "OTHER" and the specific value declared in @csip:OTHERTYPE. The vocabulary will develop under the curation of the DILCIS Board as additional content information type specifications are produced.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `mets/@TYPE` attribute MUST be used to declare the category of the content held in the package, e.g. book, journal, stereograph, video, etc.. Legal values are defined in a fixed vocabulary. When the content category used falls outside of the defined vocabulary the `mets/@TYPE` value must be set to "OTHER" and the specific value declared in `mets/@csip:OTHERTYPE`. The vocabulary will develop under the curation of the DILCIS Board as additional content information type specifications are produced.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
                         <dt>METS XPath</dt><dd>mets/@TYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
@@ -175,9 +175,9 @@
             <requirement ID="CSIP3" REQLEVEL="SHOULD" RELATEDMAT="VocabularyContentCategory" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                 <description>
                     <head>Other Content Category</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">When the @TYPE attribute has the value "OTHER" the @csip:OTHERTYPE attribute MUST be used to declare the content category of the package/representation.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/@TYPE` attribute has the value "OTHER" the `mets/@csip:OTHERTYPE` attribute MUST be used to declare the content category of the package/representation.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/@csip:OTHERTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets[@TYPE='OTHER']/@csip:OTHERTYPE</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -195,9 +195,9 @@
             <requirement ID="CSIP5" REQLEVEL="MAY" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                 <description>
                     <head>Other Content Information Type Specification</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">When the @csip:CONTENTINFORMATIONTYPE uses the value "OTHER" the @csip:OTHERCONTENTINFORMATIONTYPE must describe the content.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/@csip:CONTENTINFORMATIONTYPE` has the value "OTHER" the `mets/@csip:OTHERCONTENTINFORMATIONTYPE` must state the content information type.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/@csip:OTHERCONTENTINFORMATIONTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets[@csip:CONTENTINFORMATIONTYPE='OTHER']/@csip:OTHERCONTENTINFORMATIONTYPE</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -219,7 +219,7 @@
                     <head>Package header</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">General element for describing the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -227,9 +227,9 @@
             <requirement ID="CSIP7" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Package creation date</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">@CREATEDATE describes the date of creation of the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@CREATEDATE` records the date the package was created.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/@CREATEDATE</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/@CREATEDATE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -237,9 +237,9 @@
             <requirement ID="CSIP8" REQLEVEL="SHOULD" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Package last modification date</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">@LASTMODDATE is mandatory if the package has been modified.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@LASTMODDATE` is mandatory when the package has been modified.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/@LASTMODDATE</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/@LASTMODDATE</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -247,9 +247,9 @@
             <requirement ID="CSIP9" REQLEVEL="MUST" RELATEDMAT="VocabularyOAISPackageType" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>OAIS Package type information</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">@csip:OAISPACKAGETYPE is an attribute added by the CSIP for describing the type of the IP.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@csip:OAISPACKAGETYPE` is an attribute added by the CSIP for describing the type of the IP.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/@csip:OAISPACKAGETYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/@csip:OAISPACKAGETYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -259,7 +259,7 @@
                     <head>Agent</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">One mandatory agent is used to describe the software used for creating the package. Other uses of agents are described in the own implementations extending profile.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/agent</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent</dd>
                         <dt>Cardinality</dt><dd>1..n</dd>
                     </dl>
                 </description>
@@ -269,7 +269,7 @@
                     <head>Agent role</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The role of the mandatory agent is “CREATOR”.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/agent/@ROLE</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@ROLE='CREATOR']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -279,7 +279,7 @@
                     <head>Agent type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The type of the mandatory agent is “OTHER”.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/agent/@TYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@TYPE='OTHER']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -289,7 +289,7 @@
                     <head>Agent other type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The other type of the mandatory agent is “SOFTWARE”.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/agent/@OTHERTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@OTHERTYPE='SOFTWARE']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -299,7 +299,7 @@
                     <head>Agent name</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The name of the mandatory agent is the name of the software tool which was used to create the IP.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/agent/name</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent/name</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -309,7 +309,7 @@
                     <head>Agent additional information</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent has a note providing the version information for the tool which was used to create the IP.</p>
                      <dl xmlns="http://www.w3.org/1999/xhtml">
-                         <dt>METS XPath</dt><dd>metsHdr/agent/note</dd>
+                         <dt>METS XPath</dt><dd>mets/metsHdr/agent/note</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -319,7 +319,7 @@
                     <head>Classification of the agent additional information</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent note is typed with the fixed value of "SOFTWARE VERSION".</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>metsHdr/agent/note/@csip:NOTETYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent/note[@csip:NOTETYPE='SOFTWARE VERSION']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -329,10 +329,10 @@
             <requirement ID="CSIP17" REQLEVEL="SHOULD" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Descriptive metadata</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Must be used if descriptive metadata for the package content is available. Each descriptive metadata section (dmdSec) contains one description and thus is repeated when more descriptions are available.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Must be used if descriptive metadata for the package content is available. Each descriptive metadata section `mets/dmdSec` contains one description and thus is repeated when more descriptions are available.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">It is possible to transfer metadata in a package using just the descriptive metadata section and/or administrative metadata section.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec</dd>
                         <dt>Cardinality</dt><dd>0..n</dd>
                     </dl>
                 </description>
@@ -340,9 +340,9 @@
             <requirement ID="CSIP18" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Descriptive metadata identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">An xml:id identifier for the descriptive metadata section (dmdSec) used for referencing inside the package. It must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the descriptive metadata section `mets/dmdSec` used for referencing inside the package. It must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -352,7 +352,7 @@
                     <head>Descriptive metadata creation date</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Creation date of the descriptive metadata in this section.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/@CREATED</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/@CREATED</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -362,7 +362,7 @@
                     <head>Status of the descriptive metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/@STATUS</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/@STATUS</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -372,7 +372,7 @@
                     <head>Reference to the document with the descriptive metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Reference to the descriptive metadata file located in the “metadata” section of the IP.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -382,7 +382,7 @@
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@LOCTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef[@LOCTYPE='URL']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -392,7 +392,7 @@
                     <head>Type of link</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@xlink:type</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef[@xlink:type='simple']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -402,7 +402,7 @@
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. This specification recommends recording a URL type filepath within this attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@xlink:href</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@xlink:href</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -410,9 +410,9 @@
             <requirement ID="CSIP25" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Type of metadata</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the linked file. Values are taken from the list provided by the METS standard.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Values are taken from the list provided by the METS.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@MDTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@MDTYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -420,9 +420,9 @@
             <requirement ID="CSIP26" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File mime type</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type of the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@MIMETYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@MIMETYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -430,9 +430,9 @@
             <requirement ID="CSIP27" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File size</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the linked file in bytes.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@SIZE</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@SIZE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -440,9 +440,9 @@
             <requirement ID="CSIP28" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File creation date</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The date the linked file was created.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The date the referenced file was created.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@CREATED</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CREATED</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -450,9 +450,9 @@
             <requirement ID="CSIP29" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File checksum</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@CHECKSUM</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CHECKSUM</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -460,9 +460,9 @@
             <requirement ID="CSIP30" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File checksum type</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The type of checksum following the value list in the standard which used for the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The type of checksum following the value list in the standard which used for the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>dmdSec/mdRef/@CHECKSUMTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CHECKSUMTYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -472,11 +472,11 @@
             <requirement ID="CSIP31" REQLEVEL="SHOULD" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Administrative metadata</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative / preservation metadata is available, it must be described using the administrative metadata section (amdSec) element.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative / preservation metadata is available, it must be described using the administrative metadata section, `mets/amdSec`, element.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">All administrative metadata is present in one amdSec element.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">It is possible to transfer metadata in a package using just the descriptive metadata section and/or administrative metadata section.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -487,7 +487,7 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">For recording information about preservation the standard PREMIS is used. It is mandatory to include one digiprovMD element for each piece of PREMIS metadata.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">The use if PREMIS in METS is following the recommendations in <a href="http://www.loc.gov/standards/premis/guidelines2017-premismets.pdf">2017 version of PREMIS in METS Guidelines</a></p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD</dd>
                         <dt>Cardinality</dt><dd>0..n</dd>
                     </dl>
                 </description>
@@ -495,9 +495,9 @@
             <requirement ID="CSIP33" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Digital provenance metadata identfier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">An xml:id identifier for the digital provenance metadata section (digiprovMD) used for referencing inside the package. It must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the digital provenance metadata section `mets/amdSec/digiprovMD` used for internal package references. It must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -507,7 +507,7 @@
                     <head>Status of the digital provenance metadata</head>
                    <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                       <dt>METS XPath</dt><dd>amdSec/digiprovMD/@STATUS</dd>
+                       <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/@STATUS</dd>
                        <dt>Cardinality</dt><dd>0..1</dd>
                    </dl>
                </description>
@@ -517,7 +517,7 @@
                     <head>Reference to the document with the digital provenance metdata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Reference to the digital provenance metadata file stored in the “metadata” section of the IP.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -527,7 +527,7 @@
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@LOCTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef[@LOCTYPE='URL']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -537,7 +537,7 @@
                     <head>Type of link</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@xlink:type</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef[@xlink:type='simple']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -547,7 +547,7 @@
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. This specification recommends recording a URL type filepath within this attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@xlink:href</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@xlink:href</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -555,9 +555,9 @@
             <requirement ID="CSIP39" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Type of metadata</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the linked file. Values are taken from the list provided by the METS standard.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Values are taken from the list provided by the METS.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@MDTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@MDTYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -565,9 +565,9 @@
             <requirement ID="CSIP40" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File mime type</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@MIMETYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@MIMETYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -575,9 +575,9 @@
             <requirement ID="CSIP41" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File size</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the linked file in bytes.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@SIZE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@SIZE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -585,9 +585,9 @@
             <requirement ID="CSIP42" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File creation date</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Date the linked file was created.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Date the referenced file was created.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@CREATED</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CREATED</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -595,9 +595,9 @@
             <requirement ID="CSIP43" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File checksum</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@CHECKSUM</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CHECKSUM</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -605,9 +605,9 @@
             <requirement ID="CSIP44" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File checksum type</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The type of checksum following the value list in the standard which used for the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The type of checksum following the value list in the standard which used for the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/digiprovMD/mdRef/@CHECKSUMTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CHECKSUMTYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -618,7 +618,7 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">A simple rights statement may be used to describe general permissions for the package. Individual representations should state their specific rights in their representation METS file.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Available standards include <a href="http://rightsstatements.org">RightsStatements.org</a> , <a href="https://pro.europeana.eu/page/available-rights-statements">Europeana rights statements info</a>), <a href="https://github.com/mets/METS-Rights-Schema">METS Rights Schema</a> created and maintaned by the METS Board, the rights part of <a href="http://www.loc.gov/standards/premis/">PREMIS</a> as well as own local rights statements in use.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD</dd>
                         <dt>Cardinality</dt><dd>0..n</dd>
                     </dl>
                 </description>
@@ -626,9 +626,9 @@
             <requirement ID="CSIP46" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Rights metadata identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">An xml:id identifier for the rights metadata section (rightsMD) used for referencing inside the package. It must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An xml:id identifier for the rights metadata section `mets/amdSec/rightsMD` used for referencing inside the package. It must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -638,7 +638,7 @@
                     <head>Status of the rights metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/@STATUS</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/@STATUS</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -648,7 +648,7 @@
                     <head>Reference to the document with the rights metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Reference to the rights metadata file stored in the “metadata” section of the IP.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -658,7 +658,7 @@
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@LOCTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef[@LOCTYPE=`URL`]</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -669,7 +669,7 @@
                     <head></head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@xlink:type</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef[@xlink:type='simple']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -679,7 +679,7 @@
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. We  recommend recording a URL type filepath within this attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@xlink:href</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@xlink:href</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -687,9 +687,9 @@
             <requirement ID="CSIP52" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Type of metadata</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the linked file. Value is taken from the list provided by the METS standard.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Value is taken from the list provided by the METS.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@MDTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@MDTYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -697,9 +697,9 @@
             <requirement ID="CSIP53" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File mime type</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@MIMETYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@MIMETYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -707,9 +707,9 @@
             <requirement ID="CSIP54" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File size</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the linked file in bytes.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@SIZE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@SIZE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -717,9 +717,9 @@
             <requirement ID="CSIP55" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File creation date</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Date the linked file was created.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Date the referenced file was created.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@CREATED</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CREATED</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -727,9 +727,9 @@
             <requirement ID="CSIP56" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File checksum</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@CHECKSUM</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CHECKSUM</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -737,9 +737,9 @@
             <requirement ID="CSIP57" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File checksum type</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The type of checksum following the value list in the standard which used for the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The type of checksum following the value list in the standard which used for the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>amdSec/rightsMD/mdRef/@CHECKSUMTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CHECKSUMTYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -750,10 +750,10 @@
                 <description>
                     <head>File section</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The transferred content is placed in the file section in different file group elements, described in other requirements.</p>
-                    <p xmlns="http://www.w3.org/1999/xhtml">No more than one file section (fileSec) element should be present.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">No more than one file section `mets/fileSec` element should be present.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">It is possible to transfer just descriptive metadata and/or administrative metadata without files placed in this section.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -761,9 +761,9 @@
             <requirement ID="CSIP59" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File section identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">An xml:id identifier for the file section used for referencing inside the package. It must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the file section used for referencing inside the package. It must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -771,9 +771,9 @@
             <requirement ID="CSIP60" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Documentation file group</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">All documentation pertaining to the transferred content is placed in one or more file group elements with @USE attribute value "Documentation".</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All documentation pertaining to the transferred content is placed in one or more file group elements with `mets/fileSec/fileGrp/@USE` attribute value "Documentation".</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE='Documentation']</dd>
                         <dt>Cardinality</dt><dd>1..n</dd>
                     </dl>
                 </description>
@@ -781,9 +781,9 @@
             <requirement ID="CSIP113" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Schema file group</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">All XML schemas used in the information package should be referenced from one or more file groups with @USE attribute value "Schemas".</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All XML schemas used in the information package should be referenced from one or more file groups with `mets/fileSec/fileGrp/@USE` attribute value "Schemas".</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE='Schemas']</dd>
                         <dt>Cardinality</dt><dd>1..n</dd>
                     </dl>
                 </description>
@@ -793,7 +793,7 @@
                     <head>Representations file group</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">A pointer to the METS document describing the representation or pointers to the content being transferred must be present in one or more file groups with the categorisation "Representations".</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE='Representations']</dd>
                         <dt>Cardinality</dt><dd>1..n</dd>
                     </dl>
                 </description>
@@ -801,9 +801,9 @@
             <requirement ID="CSIP61" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Reference to administrative metadata</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative metadata has been provided on the file group (fileGrp) level this attribute points to the correct administrative metadata section.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative metadata has been provided at file group `mets/fileSec/fileGrp` level this attribute refers to its administrative metadata section by ID.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/@ADMID</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@ADMID</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -813,10 +813,10 @@
                     <head>Content Information Type Specification</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">An added attribute which states the name of the content information type specification used to create the package.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">The vocabulary will evolve under the curation of the DILCIS Board as additional content information type specifications are developed.</p>
-                    <p xmlns="http://www.w3.org/1999/xhtml">This attribute is mandatory when the file group @LABEL attribute value is "Representations".</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">This attribute is mandatory when the `mets/fileSec/fileGrp/@LABEL` attribute value is "Representations".</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">When the "Package type" value is "Mixed" and/or the file group describes a "Representation", then this element states the content information type specification used for the file group.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/@csip:CONTENTINFORMATIONTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@LABEL='Representations']/@csip:CONTENTINFORMATIONTYPE</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -824,9 +824,9 @@
             <requirement ID="CSIP63" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Other Content Information Type Specification</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">When the @csip:CONTENTINFORMATIONTYPE uses the value "OTHER" the @csip:OTHERCONTENTINFORMATIONTYPE must state a value for the Content Information Type Specification used.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/fileSec/fileGrp/@csip:CONTENTINFORMATIONTYPE` attribute has the value "OTHER" the `mets/fileSec/fileGrp/@csip:OTHERCONTENTINFORMATIONTYPE` must state a value for the Content Information Type Specification used.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/@csip:OTHERCONTENTINFORMATIONTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@csip:CONTENTINFORMATIONTYPE='OTHER']/@csip:OTHERCONTENTINFORMATIONTYPE</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -834,9 +834,9 @@
             <requirement ID="CSIP64" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Description of the use of the file group</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The value in the @USE is the name of the whole folder structure to the data, e.g "Documentation", "Schemas", "Representations/preingest" or "Representations/submission/data".</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The value in the `mets/fileSec/fileGrp/@USE` is the name of the whole folder structure to the data, e.g "Documentation", "Schemas", "Representations/preingest" or "Representations/submission/data".</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/@USE</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@USE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -844,9 +844,9 @@
             <requirement ID="CSIP65" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File group identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">An xml:id identifier for the file group used for referencing inside the package. It must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the file group used for internal package references. It must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -854,9 +854,9 @@
             <requirement ID="CSIP66" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The file group (fileGrp) contains the file elements which describe the file objects.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The file group `&lt;fileGrp&gt;` contains the file elements which describe the file objects.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file</dd>
                         <dt>Cardinality</dt><dd>1..n</dd>
                     </dl>
                 </description>
@@ -864,9 +864,9 @@
             <requirement ID="CSIP67" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">A xml:id unique identifier for this file across the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A unique `xml:id` identifier for this file across the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -874,9 +874,9 @@
             <requirement ID="CSIP68" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File mimetype</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@MIMETYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@MIMETYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -884,9 +884,9 @@
             <requirement ID="CSIP69" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File size</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the linked file in bytes.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@SIZE</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@SIZE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -894,9 +894,9 @@
             <requirement ID="CSIP70" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File creation date</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Date the linked file was created.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Date the referenced file was created.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@CREATED</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CREATED</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -904,9 +904,9 @@
             <requirement ID="CSIP71" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File checksum</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@CHECKSUM</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CHECKSUM</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -914,9 +914,9 @@
             <requirement ID="CSIP72" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File checksum type</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The type of checksum following the value list in the standard which used for the linked file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The type of checksum following the value list in the standard which used for the referenced file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@CHECKSUMTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CHECKSUMTYPE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -924,9 +924,9 @@
             <requirement ID="CSIP73" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File original identfication</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">If an original ID for the file has been given by the owner it can be saved in this attribute.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If an identifier for the file was supplied by the owner it can be recorded in this attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@OWNERID</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@OWNERID</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -934,9 +934,9 @@
             <requirement ID="CSIP74" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File reference to administrative metadata</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative metadata has been described for the file this attribute points to the file's administrative metadata.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative metadata has been provided for the file this attribute referd to the file's administrative metadata by ID.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@ADMID</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@ADMID</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -944,9 +944,9 @@
             <requirement ID="CSIP75" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File reference to descriptive metadata</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">If descriptive metadata has been described per file this attribute points to the file's descriptive metadata.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If descriptive metadata has been provided per file this attribute refers to the file's descriptive metadata by ID.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/@DMDID</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@DMDID</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -954,9 +954,9 @@
             <requirement ID="CSIP76" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                <description>
                     <head>File locator reference</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The location of each external file must be defined by the file location (FLocat) element using the same rules as for referencing metadata files. All references to files should be made using the XLink href attribute and the file protocol using the relative location of the file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The location of each external file must be defined by the file location `&lt;FLocat&gt;` element using the same rules as for referencing metadata files. All references to files should be made using the XLink href attribute and the file protocol using the relative location of the file.</p>
                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                       <dt>METS XPath</dt><dd>fileSec/fileGrp/file/FLocat</dd>
+                       <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat</dd>
                        <dt>Cardinality</dt><dd>1..1</dd>
                    </dl>
                </description>
@@ -966,7 +966,7 @@
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/FLocat/@LOCTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat[@LOCTYPE='URL']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -976,7 +976,7 @@
                     <head>Type of link</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/FLocat/@xlink:type</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat[@xlink:type='simple']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -986,7 +986,7 @@
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. We  recommend recording a URL type filepath within this attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>fileSec/fileGrp/file/FLocat/@xlink:href</dd>
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat/@xlink:href</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -996,12 +996,12 @@
             <requirement ID="CSIP80" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Structural description of the package</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The structural map (structMap) element is the only mandatory element in the METS standard.</p>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The structMap in CSIP describes the highest logical structure of the IP.</p>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Each METS file must include ONE structural map (structMap) element used exactly as described here. </p>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Institutions can add their own additional custom structural maps as separate structMap sections.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The structural map `&lt;structMap&gt;` element is the only mandatory element in the METS.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `&lt;structMap&gt;` in the CSIP describes the highest logical structure of the IP.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Each METS file must include ONE structural map `&lt;structMap&gt;` element used exactly as described here. </p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Institutions can add their own additional custom structural maps as separate `&lt;structMap&gt;` sections.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap</dd>
                         <dt>Cardinality</dt><dd>1..n</dd>
                     </dl>
                 </description>
@@ -1009,9 +1009,9 @@
             <requirement ID="CSIP81" REQLEVEL="MUST" RELATEDMAT="VocabularyStructMapType" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Type of structural description</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The type attribute of the structural map (structMap) is set to value “PHYSICAL” from the vocabulary.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `mets/structMap/@TYPE` attribute must take the value “PHYSICAL” from the vocabulary.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/@TYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1019,9 +1019,9 @@
             <requirement ID="CSIP82" REQLEVEL="MUST" RELATEDMAT="VocabularyStructMapLabel" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Name of the structural description</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The label attribute is set to value “CSIP structMap” from the vocabulary.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `mets/structMap/@LABEL` attribute value is set to “CSIP structMap” from the vocabulary.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/@LABEL</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1029,9 +1029,9 @@
             <requirement ID="CSIP83" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Structural description identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">An xml:id identifier for the structural description (structMap) used for referencing inside the package. It must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the structural description (structMap) used for internal package references. It must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1039,9 +1039,9 @@
             <requirement ID="CSIP84" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Main structural division</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The structural map consist of one main division.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The structural map comprises a single division.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1049,9 +1049,9 @@
             <requirement ID="CSIP85" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Main structural division identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, xml:id identifier must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1059,9 +1059,9 @@
             <requirement ID="CSIP86" REQLEVEL="MUST" RELATEDMAT="CSIP1" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Main structural division label</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The package's top-level structural division (div) element must have an @LABEL attribute value identical to the package identifier, i.e. the same value as the mets/@OBJID attribute.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The package's top-level structural division `&lt;div&gt;` element's `@LABEL` attribute value must be identical to the package identifier, i.e. the same value as the `mets/@OBJID` attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/@LABEL</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/@LABEL</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1072,7 +1072,7 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">The metadata referenced in the administrative and/or descriptive metadata section is described in the structural map with one sub division.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">When the transfer consist of only administrative and/or descriptive metadata this is the only sub division that occurs.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Metadata']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1080,9 +1080,9 @@
             <requirement ID="CSIP89" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Metadata division identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, xml:id identifier must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Metadata']/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1090,9 +1090,9 @@
             <requirement ID="CSIP90" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Metadata division label</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The metadata division (div) element in the package uses the value "Metadata" as the value for the attribute LABEL.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The metadata division `&lt;div&gt;` element's `@LABEL` attribute value must be "Metadata".</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@LABEL</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Metadata']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1100,10 +1100,10 @@
             <requirement ID="CSIP91" REQLEVEL="SHOULD" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Metadata division administrative metadata referencing</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">When there are administrative metadata and the amdSec is present, all administrative metadata MUST be referenced via the administrative sections different identifiers.</p>
-                    <p xmlns="http://www.w3.org/1999/xhtml">All the different identifiers is named in the same @AMDID using space as the divider.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When there is administrative metadata and the amdSec is present, all administrative metadata MUST be referenced via the administrative sections different identifiers.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All of the `&lt;amdSec&gt;` identifiers are listed in a single `@AMDID` using spaces as delimeters.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@ADMID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Metadata']/@ADMID</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -1112,9 +1112,9 @@
                 <description>
                     <head>Metadata division descriptive metadata referencing</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">When there are descriptive metadata and one or more dmdSec is present, all descriptive metadata MUST be referenced via the descriptive section identifiers.</p>
-                    <p xmlns="http://www.w3.org/1999/xhtml">All the different identifiers is named in the same @DMDID using space as the divider.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Every `&lt;dmdSec&gt;` identifiers are listed in a single `@DMDID` attribute using spaces as delimeters.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@DMDID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Metadata']/@DMDID</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -1124,7 +1124,7 @@
                     <head>Documentation division</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The documentation referenced in the file section file groups is described in the structural map with one sub division.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Documentation']</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -1134,7 +1134,7 @@
                     <head>Documentation division identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, xml:id identifier must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Documentation']/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1142,9 +1142,9 @@
             <requirement ID="CSIP95" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Documentation division label</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The documentation division (div) element in the package uses the value "Documentation" from the vocabulary as the value for the attribute LABEL.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The documentation division `&lt;div&gt;` element in the package uses the value "Documentation" from the vocabulary as the value for the attribute LABEL.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@LABEL</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Documentation']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1152,9 +1152,9 @@
             <requirement ID="CSIP96" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Documentation file referencing</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">All file groups contaning documentation described in the package are referenced via the relevant file group identifiers. One file group refrence per fptr-element</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All file groups contaning documentation described in the package are referenced via the relevant file group identifiers. There MUST be one file group refrence per `&lt;fptr&gt;` element.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/fptr</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Documentation']/fptr</dd>
                         <dt>Cardinality</dt><dd>0..n</dd>
                     </dl>
                 </description>
@@ -1162,10 +1162,10 @@
             <requirement ID="CSIP116" REQLEVEL="MUST" RELATEDMAT="CSIP60 CSIP65" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Documentation file group reference pointer</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The pointer to the identfier for the "Documentation" file group.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An reference, by ID, to the "Documentation" file group.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Related to the requirements CSIP60 which describes the "Documentation" file group and CSIP65 which describes the file group identfier.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/fptr/@FILEID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Documentation']/fptr/@FILEID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1175,7 +1175,7 @@
                     <head>Schema division</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The schemas referenced in the file section file groups are described in the structural map within a single sub-division.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Schemas']</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -1183,9 +1183,9 @@
             <requirement ID="CSIP98" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Schema division identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, xml:id identifier must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Schemas']/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1193,30 +1193,30 @@
             <requirement ID="CSIP99" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Schema division label</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The schema division (div) element in the package uses the value "Schemas" from the vocabulary as the value for the attribute LABEL.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The schema division `&lt;div&gt;` element's `@LABEL` attribute has the value "Schemas" from the vocabulary.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@LABEL</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Schemas']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
             </requirement>
             <requirement ID="CSIP100" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
-                    <head>Schema file referencing</head>
+                    <head>Schema file reference</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">All file groups containing schemas described in the package are referenced via the relevant file group identifiers. One file group refrence per fptr-element</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/fptr</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Schemas']/fptr</dd>
                         <dt>Cardinality</dt><dd>0..n</dd>
                     </dl>
                 </description>
             </requirement>
             <requirement ID="CSIP118" REQLEVEL="MUST" RELATEDMAT="CSIP113 CSIP65" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
-                    <head>Schema file group reference pointer</head>
+                    <head>Schema file group reference</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The pointer to the identfier for the "Schema" file group.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Related to the requirements CSIP113 which describes the "Schema" file group and CSIP65 which describes the file group identfier.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/fptr/@FILEID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Schemas']/fptr/@FILEID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1224,9 +1224,9 @@
             <requirement ID="CSIP101" REQLEVEL="SHOULD" EXAMPLES="structMapExample1">
                 <description>
                     <head>Content division</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">When no representations are present the content referenced in the file section file group with @USE attribute value "Representations" is described in the structural map as a single sub division.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When no representations are present the content referenced in the file section file group with `@USE` attribute value "Representations" is described in the structural map as a single sub division.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Representations']</dd>
                         <dt>Cardinality</dt><dd>0..1</dd>
                     </dl>
                 </description>
@@ -1236,7 +1236,7 @@
                     <head>Content division identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, xml:id identifier must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Representations']/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1244,30 +1244,30 @@
             <requirement ID="CSIP103" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel" EXAMPLES="structMapExample1">
                 <description>
                     <head>Content division label</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The package's content division (div) element must have the @LABEL attribute value "Representations", taken from the vocabulary.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The package's content division `&lt;div&gt;` element must have the `@LABEL` attribute value "Representations", taken from the vocabulary.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@LABEL</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Representations']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
             </requirement>
             <requirement ID="CSIP104" REQLEVEL="MUST" EXAMPLES="structMapExample1">
                 <description>
-                    <head>File division file referencing</head>
+                    <head>Content division file references</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">All file groups containing content described in the package are referenced via the relevant file group identifiers. One file group refrence per fptr-element</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/fptr</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Representations']/fptr</dd>
                         <dt>Cardinality</dt><dd>0..n</dd>
                     </dl>
                 </description>
             </requirement>
             <requirement ID="CSIP119" REQLEVEL="MUST" RELATEDMAT="CSIP114 CSIP65" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
-                    <head>Schema file group reference pointer</head>
+                    <head>Content division file group references</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The pointer to the identfier for the "Representations" file group.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Related to the requirements CSIP114 which describes the "Representations" file group and CSIP65 which describes the file group identfier.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/fptr/@FILEID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div[@LABEL='Representations']/fptr/@FILEID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1278,7 +1278,7 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">When a package consists of multiple representations, each described by a representation level METS.xml document, there is a discrete representation div element for each representation.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Each representation div references the representation level METS.xml document, documenting the structure of the package and its constituent representations.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div</dd>
                         <dt>Cardinality</dt><dd>0..n</dd>
                     </dl>
                 </description>
@@ -1286,9 +1286,9 @@
             <requirement ID="CSIP106" REQLEVEL="MUST" EXAMPLES="structMapExample2">
                 <description>
                     <head>Representations division identifier</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, xml:id identifier must be unique within the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@ID</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div/@ID</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1296,10 +1296,10 @@
             <requirement ID="CSIP107" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="structMapExample2">
                 <description>
                     <head>Representations division label</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The package's representation division (div) element @LABEL attribute value must be the path to the representation level METS document.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The package's representation division `&lt;div&gt;` element `@LABEL` attribute value must be the path to the representation level METS document.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">This requirement gives the same value to be used as the requirement named "File group identifier" (CSIP64)</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/@LABEL</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div/@LABEL</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1310,7 +1310,7 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">The file group containing the files described in the package are referenced via the relevant file group identifier.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Related to the requirements CSIP114 which describes the "Representations" file group and CSIP65 which describes the file group identfier.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/mptr/@xlink:title</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div/mptr/@xlink:title</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1318,9 +1318,9 @@
             <requirement ID="CSIP109" REQLEVEL="MUST" EXAMPLES="structMapExample2">
                 <description>
                     <head>Representation METS pointer</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The division (div) of the specific representation includes one occurrence of the METS pointer (mptr) element, pointing to the appropriate representation METS file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The division `&lt;div&gt;` of the specific representation includes one occurrence of the METS pointer `&lt;mptr&gt;` element, pointing to the appropriate representation METS file.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/mptr</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL' and @LABEL='CSIP structMap']/div/div/mptr</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1330,7 +1330,7 @@
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. We  recommend recording a URL type filepath within this attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/mptr/@xlink:href</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap/div/div/mptr/@xlink:href</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1340,7 +1340,7 @@
                     <head>Type of link</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/mptr/@xlink:type</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap/div/div/mptr[@xlink:type='simple']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1350,7 +1350,7 @@
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>structMap/div/div/mptr/@LOCTYPE</dd>
+                        <dt>METS XPath</dt><dd>mets/structMap/div/div/mptr[@LOCTYPE='URL']</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
                     </dl>
                 </description>
@@ -1428,7 +1428,7 @@
             <p xmlns="http://www.w3.org/1999/xhtml">Do we need a note?</p>
         </note>
     </tool>
-    <Example ID="metsRootElementExample1" LABEL="METS root element showing use of csip:@OTHERTYPE attribute when an appropriate package content category value is not available in the vocabulary. The @TYPE attribute value is set to OTHER.">
+    <Example ID="metsRootElementExample1" LABEL="METS root element showing use of `csip:@OTHERTYPE` attribute when an appropriate package content category value is not available in the vocabulary. The `@TYPE` attribute value is set to OTHER.">
         <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:mets="http://www.loc.gov/METS/"
             xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -1441,7 +1441,7 @@
             xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://dilcis.eu/XML/METS/CSIPExtensionMETS https://dilcis.eu/XML/METS/CSIPExtensionMETS/DILCISExtensionMETS.xsd">
          </mets:mets>
     </Example>
-    <Example ID="metsRootElementExample2" LABEL="METS root element illustrating the use of a custom csip:@OTHERCONTENTINFORMATIONTYPE attribute value when the correct content type value does note exist in the vocabulary. The csip:@CONTENTINFORMATIONTYPE attribute value is set to OTHER.">
+    <Example ID="metsRootElementExample2" LABEL="METS root element illustrating the use of a custom `csip:@OTHERCONTENTINFORMATIONTYPE` attribute value when the correct content type value does note exist in the vocabulary. The `csip:@CONTENTINFORMATIONTYPE` attribute value is set to OTHER.">
         <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:mets="http://www.loc.gov/METS/"
             xmlns:xlink="http://www.w3.org/1999/xlink"


### PR DESCRIPTION
- updated profile version and release date;
- wrapped all @ATTRIBUTE occurrences as `@ATTRIBUTE` or an appropriate xPath;
- replaced (elementName) occurrences with `<elementName>` or an appropriate xPath;
- improved stock phrases (use "reference" not "pointer" or "points to" | use "referenced" rather than "linked"); and
- made requirment xPaths more specific.