### PR TITLE
FIX - CSIP Structural Map LABEL value

### DIFF
--- a/profile/CSIP.xml
+++ b/profile/CSIP.xml
@@ -1019,7 +1019,7 @@
             <requirement ID="CSIP82" REQLEVEL="MUST" RELATEDMAT="VocabularyStructMapLabel" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Name of the structural description</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The label attribute is set to value “CSIP structMap” from the vocabulary.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The label attribute is set to value “CSIP” from the vocabulary.</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
                         <dt>METS XPath</dt><dd>structMap/@LABEL</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>
@@ -1545,7 +1545,7 @@
         </mets:fileSec>
     </Example>
     <Example ID="structMapExample1" LABEL="METS example of the mandatory structural map">
-        <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP structMap">
+        <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP">
             <mets:div ID="uuid-638362BC-65D9-4DA7-9457-5156B3965A18" LABEL="uuid-4422c185-5407-4918-83b1-7abfa77de182">
                 <mets:div ID="uuid-A4E1C5B6-CD9B-43EF-8F0C-3FD3AB688F81" LABEL="Metadata" ADMID="uuid-9124DA4D-3736-4F69-8355-EB79A22E943F uuid-48C18DD8-2561-4315-AC39-F941CBB138B3" DMDID="uuid-906F4F12-BA52-4779-AE2C-178F9206111F"/>
                 <mets:div ID="uuid-4ACDC6F3-8A36-4A00-A85F-84A56415E86I" LABEL="Documentation">
@@ -1561,7 +1561,7 @@
         </mets:structMap>
     </Example>
     <Example ID="structMapExample2" LABEL="METS example of the mandatory structural map including representations">
-        <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP structMap">
+        <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP">
             <mets:div ID="uuid-638362BC-65D9-4DA7-9457-5156B3965A18" LABEL="uuid-4422c185-5407-4918-83b1-7abfa77de182">
                <mets:div ID="uuid-A4E1C5B6-CD9B-43EF-8F0C-3FD3AB688F81" LABEL="Metadata" ADMID="uuid-9124DA4D-3736-4F69-8355-EB79A22E943F uuid-48C18DD8-2561-4315-AC39-F941CBB138B3 uuid-9124DA4D-3736-4F69-8355-EB79A22E943G uuid-48C18DD8-2561-4315-AC39-F941CBB138B4" DMDID="uuid-906F4F12-BA52-4779-AE2C-178F9206111F"/>
                 <mets:div ID="uuid-26757DC2-4C0F-4431-85B5-5943D1AB5CA3" LABEL="Schemas">
@@ -1628,7 +1628,7 @@
                     </mets:file>
                 </mets:fileGrp>
             </mets:fileSec>
-            <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP structMap">
+            <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP">
                 <mets:div ID="uuid-638362BC-65D9-4DA7-9457-5156B3965A18" LABEL="uuid-4422c185-5407-4918-83b1-7abfa77de182">
                     <mets:div ID="uuid-A4E1C5B6-CD9B-43EF-8F0C-3FD3AB688F81" LABEL="Metadata" ADMID="uuid-9124DA4D-3736-4F69-8355-EB79A22E943F uuid-48C18DD8-2561-4315-AC39-F941CBB138B3" DMDID="uuid-906F4F12-BA52-4779-AE2C-178F9206111F"/>
                     <mets:div ID="uuid-4ACDC6F3-8A36-4A00-A85F-84A56415E86I" LABEL="Documentation">
@@ -1711,7 +1711,7 @@
                     </mets:file>
                 </mets:fileGrp>
             </mets:fileSec>
-            <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP structMap">
+            <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP">
                 <mets:div ID="uuid-638362BC-65D9-4DA7-9457-5156B3965A18" LABEL="uuid-4422c185-5407-4918-83b1-7abfa77de182">
                     <mets:div ID="uuid-A4E1C5B6-CD9B-43EF-8F0C-3FD3AB688F81" LABEL="Metadata" ADMID="uuid-9124DA4D-3736-4F69-8355-EB79A22E943F uuid-48C18DD8-2561-4315-AC39-F941CBB138B3 uuid-9124DA4D-3736-4F69-8355-EB79A22E943G uuid-48C18DD8-2561-4315-AC39-F941CBB138B4" DMDID="uuid-906F4F12-BA52-4779-AE2C-178F9206111F"/>
                     <mets:div ID="uuid-26757DC2-4C0F-4431-85B5-5943D1AB5CA3" LABEL="Schemas" CONTENTIDS="">

--- a/schema/CSIPVocabularyStructMapLabel.xml
+++ b/schema/CSIPVocabularyStructMapLabel.xml
@@ -6,8 +6,8 @@
             <p>Vocabulary derived from E-ARK</p>
         </Information>
         <Entry>
-            <Term lang="en">CSIP structMap</Term>
-            <Definition>A label for the mandatory structural map</Definition>
+            <Term lang="en">CSIP</Term>
+            <Definition>The label value of the mandatory CSIP `&lt;structMap&gt;` element.</Definition>
         </Entry>
     </Vocabulary>
 </Vocabularies>

--- a/specification/implementation/metadata/mets/structmap/index.md
+++ b/specification/implementation/metadata/mets/structmap/index.md
@@ -1,22 +1,19 @@
-### 5.3.6.	Use of the METS structural map (element structMap)
-The METS structural map section is the only element mandatory in the METS specification and it is intended
-to provide an overview of components described in the METS document. It can also link the elements of that
-structure to associated content files and metadata. In CSIP the structMap describes the higher level structure of all the content in the package and may link to representations.
+### 5.3.6.	Use of the METS structural map (`<structMap>`)
+The METS structural map element is the only mandatory element in the METS specification. It provides an overview of the components described in the METS document. It can also link the elements in the structure to associated content files and metadata. In the CSIP the `<structMap>` describes the higher level structure of all the content in the package and may link to representations.
 
 The CSIP requires the inclusion of one mandatory structural map according to the principles described below.
-However, implementers are welcome to define additional structural maps for their internal purposes by
-repeating the structMap element.
+However, implementers are welcome to define additional structural maps for their internal purposes by repeating the `<structMap>` element.
 The most crucial requirements for the CSIP mandated structural map are as follows:
 
-- The structMap element has a mandatory attribute @LABEL which has the fixed value of “CSIP structMap”. The @LABEL attribute is used to distinguish the Common Specification mandated structural map occurrence from any other, user-defined, structural maps. As such we can also derive the requirement, that any user-defined structural maps must not use the @LABEL value of “CSIP structMap”;
-- The package structure is documented using METS division (div) elements which can be arranged in nested tree structures. The CSIP organises it's constituent div elements in a single root structural division element. 
-  - This top level structural division must use the package identifier as the value of its @LABEL attribute.
-- The internal structure of the structural map (expressed by div elements) follows the CSIP high level physical structure as described in Section 4, therefore grouping together metadata, representations, schemas, documentation and user-defined folders into their own div elements;
-  - All div elements must use the attribute LABEL with the value being the name of the folder (as an example “metadata”)
-- In  case both package and representation METS files exist, the structural map in the package METS file
-  - Reference the fileGrp which describes all files in all folders with the exception of the content of the representation folders
-  - Lists all representations (as separate div elements)
-  - Lists only the appropriate representation METS file using the mptr element as the content of the representation
-- The structural map in the representations METS file use the structural map the same way describing the representation structural map with no exceptions
+- The `<structMap>` element's `@LABEL` attribute is mandatory and must have the value “CSIP”. The `@LABEL` attribute distinguishes the CSIP mandated structural maps from other structural maps. NOTE this means that the "CSIP" `@LABEL` value should be treated as a unique id and not applied to other `<structMap>` elements;
+- The package structure is documented using METS division `<div>` elements which can be arranged in nested tree structures. The CSIP organises it's constituent `<div>` elements in a single root structural `<div>` element.
+  - This top level structural `<div>` element must use the package identifier as the value of its `@LABEL` attribute.
+- The internal structure of the structural map (expressed by `<div>` elements) follows the CSIP high level physical structure described in Section 4, and groups metadata, representations, schemas, documentation and user-defined folders into discrete `<div>` elements;
+  - All `<div>` elements must have an `@LABEL` attribute with the value identical to the folder name, e.g. “metadata”;
+- When both package and representation METS files are present, the structural map in the Package METS document:
+  - References the `<fileGrp>` which describes every file in every folder, with the exception of the content of the representation folders
+  - Lists all representations (as separate `<div>` elements)
+  - Lists only the appropriate representation METS file using the `<mptr>` element as the content of the representation
+- The structural map in the representations METS file uses the structural map in an identical manner, describing all representation structural map with no exceptions
 
-The specific requirements for elements, sub-elements and attributes are listed in the following table. Note that the area, seq and par elements are not discussed below.
+The specific requirements for elements, sub-elements and attributes are listed in the following table. Note that the `<area>`, `<seq>` and `<par>` elements are not discussed below.

--- a/specification/index.md
+++ b/specification/index.md
@@ -40,7 +40,7 @@ Contents
 	    - [5.3.3 Use of the METS descriptive metadata section (element dmdSec)](#533-use-of-the-mets-descriptive-metadata-section-element-dmdsec)
 	    - [5.3.4.	Use of the METS administrative metadata section (element amdSec)](#534-use-of-the-mets-administrative-metadata-section-element-amdsec)
 	    - [5.3.5.	Use of the METS file section (element fileSec)](#535-use-of-the-mets-file-section-element-filesec)
-	    - [5.3.6.	Use of the METS structural map (element structMap)](#536-use-of-the-mets-structural-map-element-structmap)
+	    - `[5.3.6.	Use of the METS structural map (element structMap)](#536-use-of-the-mets-structural-map-element-structmap)`
 		- [5.4. Use of PREMIS](#54-use-of-premis)
 	- [6. Implementation considerations](#6-implementation-considerations)
 	  - [6.1.	Content Information Type Specifications](#61-content-information-type-specifications)


### PR DESCRIPTION
- changed mandatory value from "CSIP structMap" to "CSIP"; and
- tightened text and improved typography in `structmap/index.md`.