### PR TITLE
FIX - Infotype references and notetype values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 sudo: required
 language: java
 jdk:
@@ -19,7 +19,7 @@ script:
   - mvn clean package
   - java -jar target/mets-profile-proc.jar ../profile/E-ARK-CSIP.xml
   - cd ..
-  - docker run -it --rm -v "$PWD:/source" --entrypoint /source/create-site.sh eark4all/spec-pdf-publisher
+  - docker run -it --rm -v "$PWD:/source" -u "$(id -u):$(id -g)" --entrypoint /source/create-site.sh eark4all/spec-pdf-publisher
   - bundle install
   - bundle exec jekyll build -s ./docs -d ./_site
   - bundle exec htmlproofer ./_site --file-ignore /javadoc/ --only-4xx --check-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - bash create-site.sh
   - bundle install
   - bundle exec jekyll build -s ./docs -d ./_site
-  - bundle exec htmlproofer ./_site --file-ignore /javadoc/ --only-4xx --check-html
+#  - bundle exec htmlproofer ./_site --file-ignore /javadoc/ --only-4xx --check-html
   - cd spec-publisher
   - git checkout feat/pdf-publication
   - mvn clean package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: java
 jdk:
   - openjdk8
-  - oraclejdk8
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y texlive texlive-base texlive-latex-extra texlive-fonts-extra

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - bash create-site.sh
   - bundle install
   - bundle exec jekyll build -s ./docs -d ./_site
-#  - bundle exec htmlproofer ./_site --file-ignore /javadoc/ --only-4xx --check-html
+  - bundle exec htmlproofer ./_site --file-ignore /javadoc/ --only-4xx --check-html
   - cd spec-publisher
   - git checkout feat/pdf-publication
   - mvn clean package

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - mvn clean package
   - java -jar target/mets-profile-proc.jar ../profile/E-ARK-CSIP.xml
   - cd ..
-  - bash create-site.sh
+  - docker run -it --rm -v "$PWD:/source" --entrypoint /source/create-site.sh eark4all/spec-pdf-publisher
   - bundle install
   - bundle exec jekyll build -s ./docs -d ./_site
   - bundle exec htmlproofer ./_site --file-ignore /javadoc/ --only-4xx --check-html

--- a/create-pdf.sh
+++ b/create-pdf.sh
@@ -7,7 +7,8 @@ echo "Generating PDF from markdown"
 bash "$SCRIPT_DIR/spec-publisher/utils/create-venv.sh"
 
 command -v markdown-pp >/dev/null 2>&1 || {
-  tmpdir=$(dirname $(mktemp -u))
+  tmpdir=$(dirname "$(mktemp -u)")
+  # shellcheck source=/tmp/.venv-markdown/bin/activate
   source "$tmpdir/.venv-markdown/bin/activate"
 }
 echo " - MARKDOWN-PP: Preparing Postface markdown"
@@ -42,7 +43,8 @@ then
 fi
 
 command -v markdown-pp >/dev/null 2>&1 || {
-  tmpdir=$(dirname $(mktemp -u))
+  tmpdir=$(dirname "$(mktemp -u)")
+  # shellcheck source=/tmp/.venv-markdown/bin/activate
   source "$tmpdir/.venv-markdown/bin/activate"
 }
 echo " - MARKDOWN-PP: Preparing PDF markdown"

--- a/create-site.sh
+++ b/create-site.sh
@@ -15,6 +15,24 @@ then
   rm -rf ./docs/figs
 fi
 
+if [ -d ./docs/profile ]
+then
+  echo " - removing existing profile directory"
+  rm -rf ./docs/profile
+fi
+
+if [ -d ./docs/schema ]
+then
+  echo " - removing existing schema directory"
+  rm -rf ./docs/schema
+fi
+
+if [ -d ./docs/archive ]
+then
+  echo " - removing existing archive directory"
+  rm -rf ./docs/archive
+fi
+
 bash "$SCRIPT_DIR/spec-publisher/utils/create-venv.sh"
 
 command -v markdown-pp >/dev/null 2>&1 || {

--- a/create-site.sh
+++ b/create-site.sh
@@ -36,7 +36,8 @@ fi
 bash "$SCRIPT_DIR/spec-publisher/utils/create-venv.sh"
 
 command -v markdown-pp >/dev/null 2>&1 || {
-  tmpdir=$(dirname $(mktemp -u))
+  tmpdir=$(dirname "$(mktemp -u)")
+  # shellcheck source=/tmp/.venv-markdown/bin/activate
   source "$tmpdir/.venv-markdown/bin/activate"
 }
 

--- a/profile/E-ARK-CSIP.xml
+++ b/profile/E-ARK-CSIP.xml
@@ -5,7 +5,7 @@
     xmlns:mets="http://www.loc.gov/METS/"
     xmlns:csip="https://dilcis.eu/XML/METS/CSIPExtensionMETS"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd" STATUS="provisional" REGISTRATION="unregistered" ID="V2.0.2">
+    xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd" STATUS="provisional" REGISTRATION="unregistered" ID="V2.0.3">
     <URI LOCTYPE="URL" ASSIGNEDBY="local">https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml</URI>
     <title>E-ARK CSIP METS Profile</title>
     <abstract>This base profile describes the Common Specification for Information Packages (CSIP) and the implementation of METS for packaging OAIS conformant Information Packages. The profile is accompanied with a textuall document explaning the details of use of this profile.

--- a/profile/E-ARK-CSIP.xml
+++ b/profile/E-ARK-CSIP.xml
@@ -3,7 +3,7 @@
 <METS_Profile xmlns="http://www.loc.gov/METS_Profile/v2"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:mets="http://www.loc.gov/METS/"
-    xmlns:csip="https://dilcis.eu/XML/METS/CSIPExtensionMETS"
+    xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd" STATUS="provisional" REGISTRATION="unregistered" ID="V2.0.3">
     <URI LOCTYPE="URL" ASSIGNEDBY="local">https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml</URI>
@@ -1434,27 +1434,27 @@
         <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:mets="http://www.loc.gov/METS/"
             xmlns:xlink="http://www.w3.org/1999/xlink"
-            xmlns:csip="https://dilcis.eu/XML/METS/CSIPExtensionMETS"
+            xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
             OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182"
             LABEL="Sample CSIP Information Package"
             TYPE="OTHER"
             csip:OTHERTYPE="Patterns"
             PROFILE="https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml"
-            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://dilcis.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
+            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
          </mets:mets>
     </Example>
     <Example ID="metsRootElementExample2" LABEL="METS root element illustrating the use of a custom `csip:@OTHERCONTENTINFORMATIONTYPE` attribute value when the correct content type value does note exist in the vocabulary. The `csip:@CONTENTINFORMATIONTYPE` attribute value is set to OTHER.">
         <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:mets="http://www.loc.gov/METS/"
             xmlns:xlink="http://www.w3.org/1999/xlink"
-            xmlns:csip="https://dilcis.eu/XML/METS/CSIPExtensionMETS"
+            xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
             OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182"
             LABEL="Sample CSIP Information Package"
             TYPE="Datasets"
             csip:CONTENTINFORMATIONTYPE="OTHER"
             csip:OTHERCONTENTINFORMATIONTYPE="FGS Personal, version 1"
             PROFILE="https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml"
-            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://dilcis.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
+            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
         </mets:mets>
     </Example>
     <Example ID="metsHdrElementExample1" LABEL="METS agent example of the mandatory agent">
@@ -1586,13 +1586,13 @@
         <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:mets="http://www.loc.gov/METS/"
             xmlns:xlink="http://www.w3.org/1999/xlink"
-            xmlns:csip="https://dilcis.eu/XML/METS/CSIPExtensionMETS"
+            xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
             OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182"
             LABEL="Sample CSIP Information Package with no representations"
             TYPE="Database"
             csip:CONTENTINFORMATIONTYPE="SIARDDK"
             PROFILE="https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml"
-            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://dilcis.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
+            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
             <mets:metsHdr CREATEDATE="2018-04-24T14:37:49.602+01:00" LASTMODDATE="2018-04-24T14:37:49.602+01:00" RECORDSTATUS="NEW" csip:OAISPACKAGETYPE="SIP">
                 <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
                     <mets:name>RODA-in</mets:name>
@@ -1650,12 +1650,12 @@
         <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:mets="http://www.loc.gov/METS/"
             xmlns:xlink="http://www.w3.org/1999/xlink"
-            xmlns:csip="https://dilcis.eu/XML/METS/CSIPExtensionMETS"
+            xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
             OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182"
             LABEL="Sample CSIP Information Package with representations"
             TYPE="Database"
             PROFILE="https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml"
-            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://dilcis.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
+            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
             <mets:metsHdr CREATEDATE="2018-04-24T14:37:49.602+01:00" LASTMODDATE="2018-04-24T14:37:49.602+01:00" RECORDSTATUS="NEW" csip:OAISPACKAGETYPE="SIP">
                 <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
                     <mets:name>RODA-in</mets:name>
@@ -1697,7 +1697,7 @@
                         <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="schemas/ead2002.xsd"/>
                     </mets:file>
                 </mets:fileGrp>
-                <mets:fileGrp ID="uuid-5811D494-6045-4741-924C-A1CFA340C277" USE="Representations/preingest" csip:CONTENTINFORMATIONTYPE="Access database">
+                <mets:fileGrp ID="uuid-5811D494-6045-4741-924C-A1CFA340C277" USE="Representations/preingest" csip:CONTENTINFORMATIONTYPE="OTHER">
                     <mets:file ID="uuid-EE23344D-4F64-40C1-8E18-75839EF661FE" MIMETYPE="xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="uuid-48C18DD8-2561-4315-AC39-F941CBB138B3 uuid-9124DA4D-3736-4F69-8355-EB79A22E943F">
                         <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/preingest/METS.xml"/>
                     </mets:file>

--- a/profile/E-ARK-CSIP.xml
+++ b/profile/E-ARK-CSIP.xml
@@ -5,14 +5,14 @@
     xmlns:mets="http://www.loc.gov/METS/"
     xmlns:csip="https://dilcis.eu/XML/METS/CSIPExtensionMETS"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd" STATUS="provisional" REGISTRATION="unregistered" ID="V2.0.1">
+    xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd" STATUS="provisional" REGISTRATION="unregistered" ID="V2.0.2">
     <URI LOCTYPE="URL" ASSIGNEDBY="local">https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml</URI>
     <title>E-ARK CSIP METS Profile</title>
     <abstract>This base profile describes the Common Specification for Information Packages (CSIP) and the implementation of METS for packaging OAIS conformant Information Packages. The profile is accompanied with a textuall document explaning the details of use of this profile.
         This will enable repository interoperability and assist in the management of the preservation of digital content.
         This profile is a base profile which is extended with E-ARK implementation of SIP, AIP and DIP.
     The profile can be used as is, but it is recommended that the supplied extending implementation are used. Alternatively, an own extension fulfilling the extending needs of the implementer can be created.</abstract>
-    <date>2019-09-09T16:30:00</date>
+    <date>2020-01-08T12:00:00</date>
     <contact>
         <institution>DILCIS Board</institution>
         <address>http://dilcis.eu/</address>

--- a/schema/CSIPVocabularyNoteType.xml
+++ b/schema/CSIPVocabularyNoteType.xml
@@ -9,5 +9,9 @@
             <Term lang="en">SOFTWARE VERSION</Term>
             <Definition>Describes the version of a software</Definition>
         </Entry>
+        <Entry>
+            <Term lang="en">IDENTIFICATIONCODE</Term>
+            <Definition>Describes the identification code of an agent</Definition>
+        </Entry>
     </Vocabulary>
 </Vocabularies>

--- a/schema/DILCISExtensionMETS.xsd
+++ b/schema/DILCISExtensionMETS.xsd
@@ -4,13 +4,11 @@
     <xs:attribute name="CONTENTINFORMATIONTYPE">
         <xs:simpleType>
             <xs:restriction base="xs:string">
-                <xs:enumeration value="SMURFERMS"/>
-                <xs:enumeration value="SMURFSFSB"/>
+                <xs:enumeration value="ERMS"/>
                 <xs:enumeration value="SIARD1"/>
                 <xs:enumeration value="SIARD2"/>
                 <xs:enumeration value="SIARDDK"/>
-                <xs:enumeration value="GeoVectorGML"/>
-                <xs:enumeration value="GeoRasterGeotiff"/>
+                <xs:enumeration value="GeoData"/>
                 <xs:enumeration value="MIXED"/>
                 <xs:enumeration value="OTHER"/>
             </xs:restriction>

--- a/schema/DILCISExtensionMETS.xsd
+++ b/schema/DILCISExtensionMETS.xsd
@@ -29,7 +29,8 @@
     <xs:attribute name="NOTETYPE">
         <xs:simpleType>
             <xs:restriction base="xs:string">
-                <xs:enumeration value="SOFTWARE VERSION"/>
+              <xs:enumeration value="SOFTWARE VERSION"/>
+              <xs:enumeration value="IDENTIFICATIONCODE"/>
             </xs:restriction>
         </xs:simpleType>
     </xs:attribute>

--- a/specification/metadata.md
+++ b/specification/metadata.md
@@ -14,5 +14,5 @@ abstract: |
         Alternatively, an own extension fulfilling the extending needs of the
         implementer can be created.
 version: 2.0.2
-date: 28.10.2019
+date: 08.01.2020
 ---

--- a/specification/metadata.md
+++ b/specification/metadata.md
@@ -13,6 +13,6 @@ abstract: |
         it is recommended that the supplied extending implementation are used.
         Alternatively, an own extension fulfilling the extending needs of the
         implementer can be created.
-version: 2.0.2
+version: 2.0.3
 date: 08.01.2020
 ---

--- a/specification/postface/postface-pdf.md
+++ b/specification/postface/postface-pdf.md
@@ -109,6 +109,8 @@
   2.0.2   28.10.2019  Karin                    SYD          Fixed schema paths
                       Bredenberg
 
+  2.0.3   08.01.2020  Karin Bredenberg, &      SYD          Fixed error in value list note type.
+                      C. Wilson                OPF
 ---------------------------------------------------------------------------------------------------------------
 
 ## III. Acknowledgements

--- a/specification/postface/postface-pdf.md
+++ b/specification/postface/postface-pdf.md
@@ -14,13 +14,13 @@
 | Miguel Ferreira           | Keep Solutions                    |
 | Helder Silva              | Keep Solutions                    |
 | Carl Wilson               | Open Preservation Foundation      |
-| Karin Bredenberg          | Swedish National Archives         |
+| Karin Bredenberg          | Kommunalförbundet Sydarkivera     |
 
 ### I.I. Contributors to previous version
 
 | Name                      | Organisation                      |
 | ------------------------- | --------------------------------- |
-| Karin Bredenberg                 | National Archives of Sweden                       |
+| Karin Bredenberg                 | Kommunalförbundet Sydarkivera                     |
 | Björn Skog                       | ES Solutions                                      |
 | Anders Bo Nielsen                | Danish National Archives                          |
 | Kathrine Hougaard Edsen Johansen | Danish National Archives                          |

--- a/specification/postface/postface.md
+++ b/specification/postface/postface.md
@@ -64,6 +64,7 @@
 | 2.0.0     | 31.05.2019 | DILCIS Board, E-ARK4ALL | DILCIS Board | Specification updated after open review. |
 | 2.0.1     | 09.09.2019 | K.Bredenberg, C. Wilson, & H. Silva | NAS, OPF & KEEPS | Correction @LABEL and @USE attributes, typos, layout and PDF formatting. |
 | 2.0.2     | 28.10.2019 | Karin Bredenberg | SYD | Fixed schema paths. |
+| 2.0.3 | 08.01.2020 | K. Bredenberg, C.Wilson | SYD & OPF | Fixed error in value list note type. |
 
 ## III. Acknowledgements
 

--- a/specification/postface/postface.md
+++ b/specification/postface/postface.md
@@ -14,13 +14,13 @@
 | Miguel Ferreira           | Keep Solutions                    |
 | Helder Silva              | Keep Solutions                    |
 | Carl Wilson               | Open Preservation Foundation      |
-| Karin Bredenberg          | Swedish National Archives         |
+| Karin Bredenberg          | Kommunalförbundet Sydarkivera     |
 
 ### I.I. Contributors to previous version
 
 | Name                      | Organisation                      |
 | ------------------------- | --------------------------------- |
-| Karin Bredenberg                 | National Archives of Sweden                       |
+| Karin Bredenberg                 | Kommunalförbundet Sydarkivera                     |
 | Björn Skog                       | ES Solutions                                      |
 | Anders Bo Nielsen                | Danish National Archives                          |
 | Kathrine Hougaard Edsen Johansen | Danish National Archives                          |
@@ -62,9 +62,9 @@
 | 1.1       | 14.05.2018 | Kuldar Aas (editor), DILCIS Board | NAE | Limited proofreading and updates throughout the document. Updates in terminology. Updates in use of METS, ID and referencing section. Improved (more consistent) examples in METS section. |
 | 2.0-DRAFT | 28.11.2018 | DILCIS Board, E-ARK4ALL | DILCIS Board | Specification updated and released for open review. |
 | 2.0.0     | 31.05.2019 | DILCIS Board, E-ARK4ALL | DILCIS Board | Specification updated after open review. |
-| 2.0.1     | 09.09.2019 | K.Bredenberg, C. Wilson, & H. Silva | NAS, OPF & KEEPS | Correction @LABEL and @USE attributes, typos, layout and PDF formatting. |
+| 2.0.1     | 09.09.2019 | Karin Bredenberg, C. Wilson, & H. Silva | NAS, OPF & KEEPS | Correction @LABEL and @USE attributes, typos, layout and PDF formatting. |
 | 2.0.2     | 28.10.2019 | Karin Bredenberg | SYD | Fixed schema paths. |
-| 2.0.3 | 08.01.2020 | K. Bredenberg, C.Wilson | SYD & OPF | Fixed error in value list note type. |
+| 2.0.3 | 08.01.2020 | Karin Bredenberg, C.Wilson | SYD & OPF | Fixed error in value list note type. |
 
 ## III. Acknowledgements
 


### PR DESCRIPTION
- added new `IDENTIFICATIONCODE` value to `NOTETYPE` enumeration;
- added `IDENTIFICATIONCODE` value to `CSIPVocabularyNoteType.xml`;  and
- fixed ERMS reference;
- fixed GeoData reference; and
- bumped version number and date.
