### PR TITLE
Fix/707/xpath cardinality: Created new patch version file and updated CSIP1-4

### DIFF
--- a/profile/E-ARK-CSIP-v2-1-1.xml
+++ b/profile/E-ARK-CSIP-v2-1-1.xml
@@ -1,0 +1,1728 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 2021-01-08 Draft of E-ARK CSIP METS Profile 2.1.1 -->
+<METS_Profile xmlns="http://www.loc.gov/METS_Profile/v2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mets="http://www.loc.gov/METS/"
+    xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd" STATUS="provisional" REGISTRATION="unregistered" ID="V2.1.0">
+    <URI LOCTYPE="URL" ASSIGNEDBY="local">https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml</URI>
+    <title>E-ARK CSIP METS Profile</title>
+    <abstract>This base profile describes the Common Specification for Information Packages (CSIP) and the implementation of METS for packaging OAIS conformant Information Packages. The profile is accompanied with a text document explaning the details of use of this profile.
+        This will enable repository interoperability and assist in the management of the preservation of digital content.
+        This profile is a base profile which is extended with E-ARK implementation of SIP, AIP and DIP.
+    The profile can be used as is, but it is recommended that the supplied extending implementation are used. Alternatively, an own extension fulfilling the extending needs of the implementer can be created.</abstract>
+    <date>2021-10-01T09:00:00</date>
+    <contact>
+        <institution>DILCIS Board</institution>
+        <address>http://dilcis.eu/</address>
+        <email>info@dilcis.eu</email>
+    </contact>
+    <related_profile>This profile has no related profiles</related_profile>
+    <profile_context>
+        <resource_model>
+          <head>Principles for a package conforming to the Common Specification for Information Packages (CSIP)</head>
+            <p xmlns="http://www.w3.org/1999/xhtml"><a href="http://earkcsip.dilcis.eu/specification/specification/principles/">CSIP Principles</a></p>
+        </resource_model>
+    </profile_context>
+    <external_schema>
+        <name>E-ARK CSIP METS Extension</name>
+        <URL>http://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd</URL>
+        <context>XML-schema for the attributes added by CSIP</context>
+        <note>
+            <p xmlns="http://www.w3.org/1999/xhtml">An extension schema with the added attributes for use in this profile.</p>
+            <p xmlns="http://www.w3.org/1999/xhtml">The schema is identified using the namespace prefix csip.</p>
+        </note>
+    </external_schema>
+    <external_schema>
+        <name>PREMIS</name>
+        <URL>http://www.loc.gov/standards/premis/</URL>
+        <context>Used for preservation metadata</context>
+        <note>
+            <p xmlns="http://www.w3.org/1999/xhtml">A rule set for use with this profile is under development.</p>
+        </note>
+    </external_schema>
+    <description_rules>
+        <p xmlns="http://www.w3.org/1999/xhtml">The filepath must be decoded consistently throughout all file references within the information package.</p>
+    </description_rules>
+    <controlled_vocabularies>
+        <vocabulary ID="VocabularyContentInformationTypeSpecification">
+            <name>Content information type specification</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyContentInformationType.xml</URI>
+            <context>Values for `@csip:CONTENTINFORMATIONTYPE`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Lists the names of specific E-ARK content information type specifications supported or maintained in this METS profile.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyContentCategory">
+            <name>Content Category</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyContentCategory.xml</URI>
+            <context>Values for `mets/@type`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Declares the categorical classification of package content.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyOAISPackageType">
+            <name>OAIS Package type</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyOAISPackageType.xml</URI>
+            <context>Values for `@csip:OAISPACKAGETYPE`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the OAIS type the package belongs to in the OAIS reference model.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyNoteType">
+            <name>Note type</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyNoteType.xml</URI>
+            <context>Values for `@csip:NOTETYPE`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Provides values for the type of a note for an agent.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyAgentOtherType">
+            <name>Other agent type</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyAgentOtherType.xml</URI>
+            <context>Values for `metsHdr/agent/@OTHERTYPE`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the other agent types supported by the profile.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyIdentifierType">
+            <name>Identifier type</name>
+            <maintenance_agency>Library of Congress</maintenance_agency>
+            <URI>http://id.loc.gov/vocabulary/identifiers.html</URI>
+            <context>Values for `metsHdr/altRecordID/@TYPE`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the type of the identifier.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyStatus">
+            <name>dmdSec status</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyStatus.xml</URI>
+            <context>Values for `dmdSec/@STATUS`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the status of the descriptive metadata section (dmdSec) which is supported by the profile.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyIANAmediaTypes">
+            <name>IANA media types</name>
+            <maintenance_agency>IANAs</maintenance_agency>
+                <URI>https://www.iana.org/assignments/media-types/media-types.xhtml</URI>
+            <context>Values for `@MIMETYPE`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Valid values for the mime types of referenced files.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyFileGrpAndStructMapDivisionLabel">
+            <name>File group names</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyFileGrpAndStructMapDivisionLabel.xml</URI>
+            <context>Values for `fileGrp/@USE`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the uses of the file group `&lt;fileGrp&gt;` that are supported by the profile.</p>
+                <p xmlns="http://www.w3.org/1999/xhtml">Own names should be placed in an own extending vocabulary.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyStructMapType">
+            <name>Structural map typing</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyStructMapType.xml</URI>
+            <context>Values for `structMap/@TYPE`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the type of the structural map `&lt;structMap&gt;` that is supported by the profile.</p>
+                <p xmlns="http://www.w3.org/1999/xhtml">Own types should be placed in an own extending vocabulary.</p>
+            </description>
+        </vocabulary>
+        <vocabulary ID="VocabularyStructMapLabel">
+            <name>Structural map label</name>
+            <maintenance_agency>DILCIS Board</maintenance_agency>
+            <URI>http://earkcsip.dilcis.eu/schema/CSIPVocabularyStructMapLabel.xml</URI>
+            <context>Values for `structMap/@LABEL`</context>
+            <description>
+                <p xmlns="http://www.w3.org/1999/xhtml">Describes the label of the structural map that is supported by the profile.</p>
+                <p xmlns="http://www.w3.org/1999/xhtml">Own labels should be placed in an own extending vocabulary.</p>
+            </description>
+        </vocabulary>
+    </controlled_vocabularies>
+    <structural_requirements>
+        <metsRootElement ID="metsRootElement">
+            <requirement ID="CSIP1" REQLEVEL="MUST" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
+                <description>
+                    <head>Package Identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `mets/@OBJID` attribute is mandatory, its value is a string identifier for the METS document. For the package METS document, this should be the name/ID of the package, i.e. the name of the package root folder.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">For a representation level METS document this value records the name/ID of the representation, i.e. the name of the top-level representation folder.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/@OBJID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP2" REQLEVEL="MUST" RELATEDMAT="VocabularyContentCategory" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
+                <description>
+                    <head>Content Category</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `mets/@TYPE` attribute MUST be used to declare the category of the content held in the package, e.g. "Datasets", "Websites", "Mixes" , "Other", etc.. Legal values are defined in a fixed vocabulary. When the content category used falls outside of the defined vocabulary the `mets/@TYPE` value must be set to "OTHER" and the specific value declared in `mets/@csip:OTHERTYPE`. The vocabulary will develop under the curation of the DILCIS Board as additional content information type specifications are produced.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/@TYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP3" REQLEVEL="SHOULD" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
+                <description>
+                    <head>Other Content Category</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/@TYPE` attribute has the value "OTHER" the `mets/@csip:OTHERTYPE` attribute MUST be used to declare the content category of the package/representation. The value can either be "OTHER" or any other string that are not present in the vocabulary used in the `mets/@TYPE` attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets[@TYPE='OTHER']/@csip:OTHERTYPE</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP4" REQLEVEL="SHOULD" RELATEDMAT="VocabularyContentInformationTypeSpecification" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
+               <description>
+                    <head>Content Information Type Specification</head>
+                   <p xmlns="http://www.w3.org/1999/xhtml">Used to declare the Content Information Type Specification used when creating the package. Legal values are defined in a fixed vocabulary. The attribute is mandatory for representation level METS documents. The vocabulary will evolve under the care of the DILCIS Board as additional Content Information Type Specifications are developed.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/@csip:CONTENTINFORMATIONTYPE</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP5" REQLEVEL="MAY" RELATEDMAT="CSIP4" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
+                <description>
+                    <head>Other Content Information Type Specification</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/@csip:CONTENTINFORMATIONTYPE` has the value "OTHER" the `mets/@csip:OTHERCONTENTINFORMATIONTYPE` must state the content information type.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets[@csip:CONTENTINFORMATIONTYPE='OTHER']/@csip:OTHERCONTENTINFORMATIONTYPE</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP6" REQLEVEL="MUST" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
+                <description>
+                    <head>METS Profile</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The URL of the METS profile that the information package conforms with.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/@PROFILE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+        </metsRootElement>
+        <metsHdr ID="metsHeaderElement">
+            <requirement ID="CSIP117" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Package header</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">General element for describing the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP7" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Package creation datetime</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@CREATEDATE` records the date and time the package was created.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/@CREATEDATE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP8" REQLEVEL="SHOULD" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Package last modification datetime</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@LASTMODDATE` records the data and time the package was modified and is mandatory when the package has been modified.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/@LASTMODDATE</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP9" REQLEVEL="MUST" RELATEDMAT="VocabularyOAISPackageType" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>OAIS Package type information</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@csip:OAISPACKAGETYPE` is an additional CSIP attribute that declares the type of the IP.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/@csip:OAISPACKAGETYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP10" REQLEVEL="MUST">
+                <description>
+                    <head>Agent</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A mandatory agent element records the software used to create the package. Other uses of agents may be described in any local implementations that extend the profile.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent</dd>
+                        <dt>Cardinality</dt><dd>1..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+           <requirement ID="CSIP11" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Agent role</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent element MUST have a `@ROLE` attribute with the value “CREATOR”.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@ROLE='CREATOR']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP12" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Agent type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent element MUST have a `@TYPE` attribute with the value “OTHER”.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@TYPE='OTHER']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP13" REQLEVEL="MUST" RELATEDMAT="VocabularyAgentOtherType" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Agent other type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent element MUST have a `@OTHERTYPE` attribute with the value “SOFTWARE”.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@OTHERTYPE='SOFTWARE']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP14" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Agent name</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent's name element records the name of the software tool used to create the IP.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent/name</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP15" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Agent additional information</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent's note element records the version of the tool used to create the IP.</p>
+                     <dl xmlns="http://www.w3.org/1999/xhtml">
+                         <dt>METS XPath</dt><dd>mets/metsHdr/agent/note</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP16" REQLEVEL="MUST" RELATEDMAT="VocabularyNoteType" EXAMPLES="metsHdrElementExample1">
+                <description>
+                    <head>Classification of the agent additional information</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent element's note child has a `@csip:NOTETYPE` attribute with a fixed value of "SOFTWARE VERSION".</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/metsHdr/agent/note[@csip:NOTETYPE='SOFTWARE VERSION']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+        </metsHdr>
+        <dmdSec ID="dmdSecElement">
+            <requirement ID="CSIP17" REQLEVEL="SHOULD" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Descriptive metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Must be used if descriptive metadata for the package content is available. Each descriptive metadata section (`&lt;dmdSec&gt;`) contains a single description and must be repeated for multiple descriptions, when available.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">It is possible to transfer metadata in a package using just the descriptive metadata section and/or administrative metadata section.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec</dd>
+                        <dt>Cardinality</dt><dd>0..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP18" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Descriptive metadata identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the descriptive metadata section (`&lt;dmdSec&gt;`) used for internal package references. It must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP19" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Descriptive metadata creation datetime</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Creation date and time of the descriptive metadata in this section.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/@CREATED</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP20" REQLEVEL="SHOULD" RELATEDMAT="VocabularyStatus" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Status of the descriptive metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/@STATUS</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP21" REQLEVEL="SHOULD" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Reference to the document with the descriptive metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Reference to the descriptive metadata file located in the “metadata” section of the IP.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP22" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Type of locator</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef[@LOCTYPE='URL']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP23" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Type of link</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef[@xlink:type='simple']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP24" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Resource location</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. This specification recommends recording a URL type filepath in this attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@xlink:href</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP25" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>Type of metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Values are taken from the list provided by the METS.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@MDTYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP26" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>File mime type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@MIMETYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP27" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>File size</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@SIZE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP28" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>File creation datetime</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The creation date and time of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CREATED</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP29" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>File checksum</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CHECKSUM</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP30" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
+                <description>
+                    <head>File checksum type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A value from the METS-standard which identifies the algorithm used to calculate the checksum for the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CHECKSUMTYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+        </dmdSec>
+        <amdSec ID="amdSecElement">
+            <requirement ID="CSIP31" REQLEVEL="SHOULD" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Administrative metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative / preservation metadata is available, it must be described using the administrative metadata section (`&lt;amdSec&gt;`) element.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All administrative metadata is present in a single `&lt;amdSec&gt;` element.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">It is possible to transfer metadata in a package using just the descriptive metadata section and/or administrative metadata section.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP32" REQLEVEL="SHOULD" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Digital provenance metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">For recording information about preservation the standard PREMIS is used. It is mandatory to include one `&lt;digiprovMD&gt;` element for each piece of PREMIS metadata.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The use if PREMIS in METS is following the recommendations in <a href="http://www.loc.gov/standards/premis/guidelines2017-premismets.pdf"> the 2017 version of PREMIS in METS Guidelines.</a></p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD</dd>
+                        <dt>Cardinality</dt><dd>0..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP33" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Digital provenance metadata identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the digital provenance metadata section `mets/amdSec/digiprovMD` used for internal package references. It must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP34" REQLEVEL="SHOULD" RELATEDMAT="VocabularyStatus" EXAMPLES="amdSecExample1">
+               <description>
+                    <head>Status of the digital provenance metadata</head>
+                   <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
+                   <dl xmlns="http://www.w3.org/1999/xhtml">
+                       <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/@STATUS</dd>
+                       <dt>Cardinality</dt><dd>0..1</dd>
+                   </dl>
+               </description>
+            </requirement>
+            <requirement ID="CSIP35" REQLEVEL="SHOULD" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Reference to the document with the digital provenance metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Reference to the digital provenance metadata file stored in the “metadata” section of the IP.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP36" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Type of locator</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef[@LOCTYPE='URL']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP37" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Type of link</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef[@xlink:type='simple']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP38" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Resource location</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. This specification recommends recording a URL type filepath within this attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@xlink:href</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP39" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Type of metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Values are taken from the list provided by the METS.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@MDTYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP40" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File mime type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@MIMETYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP41" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File size</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@SIZE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP42" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File creation datetime</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Creation date and time of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CREATED</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP43" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File checksum</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CHECKSUM</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP44" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File checksum type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A value from the METS-standard which identifies the algorithm used to calculate the checksum for the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CHECKSUMTYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP45" REQLEVEL="MAY" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Rights metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A simple rights statement may be used to describe general permissions for the package. Individual representations should state their specific rights in their representation METS file.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Available standards include <a href="http://rightsstatements.org">RightsStatements.org</a>, <a href="https://pro.europeana.eu/page/available-rights-statements">Europeana rights statements info</a>, <a href="https://github.com/mets/METS-Rights-Schema">METS Rights Schema</a> created and maintained by the METS Board, the rights part of <a href="http://www.loc.gov/standards/premis/">PREMIS</a> as well as own local rights statements in use.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD</dd>
+                        <dt>Cardinality</dt><dd>0..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP46" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Rights metadata identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the rights metadata section (`&lt;rightsMD&gt;`) used for internal package references. It must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP47" REQLEVEL="SHOULD" RELATEDMAT="VocabularyStatus" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Status of the rights metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/@STATUS</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP48" REQLEVEL="SHOULD" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Reference to the document with the rights metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Reference to the rights metadata file stored in the “metadata” section of the IP.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP49" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Type of locator</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef[@LOCTYPE='URL']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP50" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Type of locator</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef[@xlink:type='simple']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP51" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Resource location</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. We  recommend recording a URL type filepath within this attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@xlink:href</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP52" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>Type of metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Value is taken from the list provided by the METS.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@MDTYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP53" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File mime type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@MIMETYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP54" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File size</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@SIZE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP55" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File creation datetime </head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Creation date and time of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CREATED</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP56" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File checksum</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CHECKSUM</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP57" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
+                <description>
+                    <head>File checksum type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A value from the METS-standard which identifies the algorithm used to calculate the checksum for the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CHECKSUMTYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+        </amdSec>
+        <fileSec ID="fileSecElement">
+            <requirement ID="CSIP58" REQLEVEL="SHOULD" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File section</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">References to all transferred content SHOULD be placed in the file section in the different file group elements, described in other requirements.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Only a single file section (`&lt;fileSec&gt;`) element should be present.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">In the case that a package only contains metadata updates, i.e. exclusively metadata files, then no file references need to be added to this section.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP59" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File section identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the file section used for internal package references. It must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP60" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Documentation file group</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All documentation pertaining to the transferred content is placed in one or more file group elements with `mets/fileSec/fileGrp/@USE` attribute value "Documentation".</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE='Documentation']</dd>
+                        <dt>Cardinality</dt><dd>1..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP113" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Schema file group</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All XML schemas used in the information package must be referenced from one or more file groups with `mets/fileSec/fileGrp/@USE` attribute value "Schemas".</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE='Schemas']</dd>
+                        <dt>Cardinality</dt><dd>1..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP114" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Representations file group</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A pointer to the METS document describing the representation or pointers to the content being transferred must be present in one or more file groups with `mets/fileSec/fileGrp/@USE` attribute value starting with "Representations" followed by the path to the folder where the representation level METS document is placed. For example "Representation/submission" and "Representation/ingest".</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE=[starts-with('Representations')]]</dd>
+                        <dt>Cardinality</dt><dd>1..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP61" REQLEVEL="MAY" RELATEDMAT="CSIP31" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Reference to administrative metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative metadata has been provided at file group `mets/fileSec/fileGrp` level this attribute refers to its administrative metadata section by ID.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@ADMID</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP62" REQLEVEL="SHOULD" RELATEDMAT="VocabularyContentInformationTypeSpecification CSIP4 CSIP114" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Content Information Type Specification</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An added attribute which states the name of the content information type specification used to create the package.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The vocabulary will evolve under the curation of the DILCIS Board as additional content information type specifications are developed.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the element "Content Information Type Specification" (CSIP4) has the value "MIXED" or the file group describes a representation, then this element states the content information type specification used for the file group.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the element "Representations file group" (CSIP114), the file group describes a representation with the `mets/fileSec/fileGrp/@USE` attribute value is starting with "Representations", then this element must state the content information type specification used for the representation.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/@csip:CONTENTINFORMATIONTYPE="MIXED"|mets/fileSec/fileGrp[@USE=[starts-with('Representations')]]/@csip:CONTENTINFORMATIONTYPE</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP63" REQLEVEL="MAY" RELATEDMAT="CSIP62" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Other Content Information Type Specification</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/fileSec/fileGrp/@csip:CONTENTINFORMATIONTYPE` attribute has the value "OTHER" the `mets/fileSec/fileGrp/@csip:OTHERCONTENTINFORMATIONTYPE` must state a value for the Content Information Type Specification used.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@csip:CONTENTINFORMATIONTYPE='OTHER']/@csip:OTHERCONTENTINFORMATIONTYPE</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP64" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Description of the use of the file group</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The value in the `mets/fileSec/fileGrp/@USE` is the name of the whole folder structure to the data, e.g "Documentation", "Schemas", "Representations/preingest" or "Representations/submission/data".</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@USE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP65" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File group identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the file group used for internal package references. It must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP66" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The file group (`&lt;fileGrp&gt;`) contains the file elements which describe the file objects.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file</dd>
+                        <dt>Cardinality</dt><dd>1..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP67" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A unique `xml:id` identifier for this file across the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP68" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File mimetype</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@MIMETYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP69" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File size</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@SIZE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP70" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File creation datetime</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Creation date and time of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CREATED</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP71" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File checksum</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CHECKSUM</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP72" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File checksum type</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A value from the METS-standard which identifies the algorithm used to calculate the checksum for the referenced file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CHECKSUMTYPE</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP73" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File original identification</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If an identifier for the file was supplied by the owner it can be recorded in this attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@OWNERID</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP74" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File reference to administrative metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If administrative metadata has been provided for the file this attribute refers to the file's administrative metadata by ID.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@ADMID</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP75" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>File reference to descriptive metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">If descriptive metadata has been provided per file this attribute refers to the file's descriptive metadata by ID.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@DMDID</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP76" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+               <description>
+                    <head>File locator reference</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The location of each external file must be defined by the file location `&lt;FLocat&gt;` element using the same rules as references for metadata files. All references to files should be made using the XLink href attribute and the file protocol using the relative location of the file.</p>
+                   <dl xmlns="http://www.w3.org/1999/xhtml">
+                       <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat</dd>
+                       <dt>Cardinality</dt><dd>1..1</dd>
+                   </dl>
+               </description>
+            </requirement>
+            <requirement ID="CSIP77" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Type of locator</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat[@LOCTYPE='URL']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP78" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Type of link</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat[@xlink:type='simple']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP79" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
+                <description>
+                    <head>Resource location</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. We  recommend recording a URL type filepath within this attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat/@xlink:href</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+        </fileSec>
+        <structMap ID="structMapElement">
+            <requirement ID="CSIP80" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Structural description of the package</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The structural map `&lt;structMap&gt;` element is the only mandatory element in the METS.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `&lt;structMap&gt;` in the CSIP describes the highest logical structure of the IP.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Every CSIP compliant METS file must include ONE structural map `&lt;structMap&gt;` element used exactly as described in this section of requirements.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Institutions can add their own additional custom structural maps as separate `&lt;structMap&gt;` sections following their own requirements.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap</dd>
+                        <dt>Cardinality</dt><dd>1..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP81" REQLEVEL="MUST" RELATEDMAT="VocabularyStructMapType" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Type of structural description</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `mets/structMap/@TYPE` attribute must take the value “PHYSICAL” from the vocabulary.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP82" REQLEVEL="MUST" RELATEDMAT="VocabularyStructMapLabel" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Name of the structural description</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The `mets/structMap/@LABEL` attribute value is set to “CSIP” from the vocabulary.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">This requirement identifies the CSIP compliant structural map `&lt;structMap&gt;` element.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP83" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Structural description identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the structural description (structMap) used for internal package references. It must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP84" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Main structural division</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The structural map comprises a single division.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP85" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Main structural division identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP88" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Metadata division</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The metadata referenced in the administrative and/or descriptive metadata section is described in the structural map with one sub division.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When the transfer consists of only administrative and/or descriptive metadata this is the only sub division that occurs.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Metadata']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP89" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Metadata division identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Metadata']/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP90" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Metadata division label</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The metadata division `&lt;div&gt;` element's `@LABEL` attribute value must be "Metadata".</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Metadata']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP91" REQLEVEL="SHOULD" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Metadata division references administrative metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The admimistrative metadata division should reference all current administrative metadata sections.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All `&lt;amdSec&gt;`s with `@STATUS='CURRENT'` SHOULD be referenced by their identifier, @ID.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The current `&lt;amdSec&gt;` @IDs are recorded in the `div[@LABEL='Metadata']/@ADMID` attribute in a space delimited list.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Metadata']/@ADMID</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP92" REQLEVEL="SHOULD" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Metadata division references descriptive metadata</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The descriptive metadata division should reference all current descriptive metadata sections.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All `&lt;dmdSec&gt;`s with `@STATUS='CURRENT'` SHOULD be referenced by their identifier, @ID.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The current `&lt;dmdSec&gt;` @IDs are recorded in the `div[@LABEL='Metadata']/@DMDID` attribute in a space delimited list.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Metadata']/@DMDID</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP93" REQLEVEL="SHOULD" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Documentation division</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The documentation referenced in the file section file groups is described in the structural map with one sub division.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP94" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Documentation division identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP95" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Documentation division label</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The documentation division `&lt;div&gt;` element in the package uses the value "Documentation" from the vocabulary as the value for the `@LABEL` attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP96" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Documentation file references</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All file groups containing documentation described in the package are referenced via the relevant file group identifiers. There MUST be one file group reference per `&lt;fptr&gt;` element.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']/fptr</dd>
+                        <dt>Cardinality</dt><dd>0..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP116" REQLEVEL="MUST" RELATEDMAT="CSIP60 CSIP65" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Documentation file group reference pointer</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">A reference, by ID, to the "Documentation" file group.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Related to the requirements CSIP60 which describes the "Documentation" file group and CSIP65 which describes the file group identifier.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']/fptr/@FILEID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP97" REQLEVEL="SHOULD" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Schema division</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The schemas referenced in the file section file groups are described in the structural map within a single sub-division.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Schemas']</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP98" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Schema division identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Schemas']/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP99" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Schema division label</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The schema division `&lt;div&gt;` element's `@LABEL` attribute has the value "Schemas" from the vocabulary.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Schemas']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP100" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Schema file reference</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All file groups containing schemas described in the package are referenced via the relevant file group identifiers. One file group reference per fptr-element</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Schemas']/fptr</dd>
+                        <dt>Cardinality</dt><dd>0..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP118" REQLEVEL="MUST" RELATEDMAT="CSIP113 CSIP65" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Schema file group reference</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The pointer to the identifier for the "Schema" file group.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Related to the requirements CSIP113 which describes the "Schema" file group and CSIP65 which describes the file group identifier.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Schemas']/fptr/@FILEID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP101" REQLEVEL="SHOULD" EXAMPLES="structMapExample1">
+                <description>
+                    <head>Content division</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When no representations are present the content referenced in the file section file group with `@USE` attribute value "Representations" is described in the structural map as a single sub division.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']</dd>
+                        <dt>Cardinality</dt><dd>0..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP102" REQLEVEL="MUST" EXAMPLES="structMapExample1">
+                <description>
+                    <head>Content division identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP103" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel" EXAMPLES="structMapExample1">
+                <description>
+                    <head>Content division label</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The package's content division `&lt;div&gt;` element must have the `@LABEL` attribute value "Representations", taken from the vocabulary.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP104" REQLEVEL="MUST" EXAMPLES="structMapExample1">
+                <description>
+                    <head>Content division file references</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">All file groups containing content described in the package are referenced via the relevant file group identifiers. One file group reference per fptr-element.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']/fptr</dd>
+                        <dt>Cardinality</dt><dd>0..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP119" REQLEVEL="MUST" RELATEDMAT="CSIP114 CSIP65" EXAMPLES="structMapExample1 structMapExample2">
+                <description>
+                    <head>Content division file group references</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The pointer to the identifier for the "Representations" file group.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Related to the requirements CSIP114 which describes the "Representations" file group and CSIP65 which describes the file group identifier.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Representations']/fptr/@FILEID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP105" REQLEVEL="SHOULD" EXAMPLES="structMapExample2">
+                <description>
+                    <head>Representation division</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">When a package consists of multiple representations, each described by a representation level METS.xml document, there should be a discrete representation div element for each representation.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Each representation div references the representation level METS.xml document, documenting the structure of the package and its constituent representations.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div</dd>
+                        <dt>Cardinality</dt><dd>0..n</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP106" REQLEVEL="MUST" EXAMPLES="structMapExample2">
+                <description>
+                    <head>Representations division identifier</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Mandatory, `xml:id` identifier must be unique within the package.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div/@ID</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP107" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="structMapExample2">
+                <description>
+                    <head>Representations division label</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The package's representation division `&lt;div&gt;` element `@LABEL` attribute value must be the path to the representation level METS document starting with the value "Representations" followed by the main folder name for example "Representations/submission" and "Representations/ingest".</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">This requirement gives the same value to be used as the requirement named "Description of the use of the file group" (CSIP64)</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div/@LABEL</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP108" REQLEVEL="MUST" RELATEDMAT="CSIP114 CSIP65" EXAMPLES="structMapExample2">
+                <description>
+                    <head>Representations division file references</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The file group containing the files described in the package are referenced via the relevant file group identifier.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Related to the requirements CSIP114 which describes the "Representations" file group and CSIP65 which describes the file group identifier.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div/mptr/@xlink:title</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP109" REQLEVEL="MUST" EXAMPLES="structMapExample2">
+                <description>
+                    <head>Representation METS pointer</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The division `&lt;div&gt;` of the specific representation includes one occurrence of the METS pointer `&lt;mptr&gt;` element, pointing to the appropriate representation METS file.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/div/div/mptr</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP110" REQLEVEL="MUST" EXAMPLES="structMapExample2">
+                <description>
+                    <head>Resource location</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. We  recommend recording a URL type filepath within this attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap/div/div/mptr/@xlink:href</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP111" REQLEVEL="MUST" EXAMPLES="structMapExample2">
+                <description>
+                    <head>Type of link</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap/div/div/mptr[@xlink:type='simple']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+            <requirement ID="CSIP112" REQLEVEL="MUST" EXAMPLES="structMapExample2">
+                <description>
+                    <head>Type of locator</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
+                    <dl xmlns="http://www.w3.org/1999/xhtml">
+                        <dt>METS XPath</dt><dd>mets/structMap/div/div/mptr[@LOCTYPE='URL']</dd>
+                        <dt>Cardinality</dt><dd>1..1</dd>
+                    </dl>
+                </description>
+            </requirement>
+         </structMap>
+         <structLink ID="structLinkElement">
+            <requirement REQLEVEL="MAY" ID="REF_METS_1">
+                <description>
+                    <head>structLink</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Section not defined or used in CSIP, additional own uses may occur.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Information regarding the structural links is found in the <a href="http://www.loc.gov/standards/mets/METSPrimer.pdf">METS Primer</a></p>
+                </description>
+            </requirement>
+        </structLink>
+        <behaviorSec ID="behaviorSecElement">
+            <requirement REQLEVEL="MAY" ID="REF_METS_2">
+                <description>
+                    <head>behaviorSec</head>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Section not defined or used in CSIP, additional own uses may occur.</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Information regarding the behaviour section is found in the <a href="http://www.loc.gov/standards/mets/METSPrimer.pdf">METS Primer</a></p>
+                </description>
+            </requirement>
+        </behaviorSec>
+    </structural_requirements>
+    <technical_requirements>
+        <content_files>
+            <requirement>
+                <description>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Requriments not stated in CSIP</p>
+                </description>
+            </requirement>
+        </content_files>
+        <behavior_files>
+            <requirement>
+                <description>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Requriments not stated in CSIP</p>
+                </description>
+            </requirement>
+        </behavior_files>
+        <metadata_files>
+            <requirement>
+                <description>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Requriments not stated in CSIP</p>
+                </description>
+            </requirement>
+        </metadata_files>
+    </technical_requirements>
+    <tool>
+        <name>ESSArch (ETP, ETA, EPP, ECORE)</name>
+        <URI>https://github.com/ESSolutions</URI>
+        <description>
+            <p xmlns="http://www.w3.org/1999/xhtml">A suite of tools for e-archiving and digital preservation. The tools provide functionality for producers to archive digital information, for archives to preserve digital information and for consumers to access archived information.</p>
+        </description>
+        <note>
+            <p xmlns="http://www.w3.org/1999/xhtml">ES Solutions - www.essolutions.se</p>
+        </note>
+    </tool>
+    <tool>
+        <name>RODA</name>
+        <URI>http://github.com/keeps/roda</URI>
+        <description>
+            <p xmlns="http://www.w3.org/1999/xhtml">RODA is a digital repository solution that delivers functionality for all the main units of the OAIS reference model. RODA is capable of ingesting, managing and providing access to the various types of digital objects produced by large corporations or public bodies. RODA is based on open-source technologies and is supported by existing standards such as the Open Archival Information System (OAIS), Metadata Encoding and Transmission Standard (METS), Encoded Archival Description (EAD), Dublin Core (DC) and PREMIS (Preservation Metadata).</p>
+        </description>
+        <note>
+            <p xmlns="http://www.w3.org/1999/xhtml">RODA is licensed under LGPLv3 for all source-code including interoperability libraries like SIP manipulation libraries.</p>
+        </note>
+    </tool>
+    <tool>
+        <name>RODA-in</name>
+        <URI>https://rodain.roda-community.org</URI>
+        <description>
+            <p xmlns="http://www.w3.org/1999/xhtml">RODA-in is a tool specially designed for producers and archivists to create Submission Information Packages (SIP) ready to be submitted to an Open Archival Information System (OAIS). The tool creates SIPs from files and folders available on the local file system.</p>
+            <p xmlns="http://www.w3.org/1999/xhtml">
+                RODA-in supports several Submission Information Package formats such as BagIt, E-ARK SIP and the Hungarian SIP format.
+            </p>
+        </description>
+        <note>
+            <p xmlns="http://www.w3.org/1999/xhtml">RODA-in is licensed under LGPLv3.</p>
+        </note>
+    </tool>
+    <Example ID="metsRootElementExample1" LABEL="METS root element showing use of `csip:@OTHERTYPE` attribute when an appropriate package content category value is not available in the vocabulary. The `@TYPE` attribute value is set to OTHER.">
+        <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:mets="http://www.loc.gov/METS/"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
+            OBJID="csip-mets-example"
+            LABEL="Sample CSIP Information Package"
+            TYPE="OTHER"
+            csip:OTHERTYPE="Patterns"
+            PROFILE="https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml"
+            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
+         </mets:mets>
+    </Example>
+    <Example ID="metsRootElementExample2" LABEL="METS root element illustrating the use of a custom `csip:@OTHERCONTENTINFORMATIONTYPE` attribute value when the correct content type value does note exist in the vocabulary. The `csip:@CONTENTINFORMATIONTYPE` attribute value is set to OTHER.">
+        <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:mets="http://www.loc.gov/METS/"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
+            OBJID="csip-mets-example"
+            LABEL="Sample CSIP Information Package"
+            TYPE="Datasets"
+            csip:CONTENTINFORMATIONTYPE="OTHER"
+            csip:OTHERCONTENTINFORMATIONTYPE="FGS Personal, version 1"
+            PROFILE="https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml"
+            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
+        </mets:mets>
+    </Example>
+    <Example ID="metsHdrElementExample1" LABEL="METS agent example of the mandatory agent">
+        <mets:metsHdr CREATEDATE="2018-04-24T14:37:49.602+01:00" LASTMODDATE="2018-04-24T14:37:49.602+01:00" RECORDSTATUS="NEW" csip:OAISPACKAGETYPE="SIP">
+            <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
+                <mets:name>RODA-in</mets:name>
+                <mets:note csip:NOTETYPE="SOFTWARE VERSION">2.1.0-beta.7</mets:note>
+            </mets:agent>
+        </mets:metsHdr>
+    </Example>
+    <Example ID="dmdSecExample1" LABEL="METS example of references to descriptive metadata which is described with an EAD document">
+        <mets:dmdSec ID="dmd-ead-file" CREATED="2018-04-24T14:37:49.609+01:00">
+            <mets:mdRef LOCTYPE="URL" MDTYPE="EAD" xlink:type="simple"  xlink:href="metadata/descriptive/ead2002.xml" MIMETYPE="application/xml" SIZE="903" CREATED="2018-04-24T14:37:49.609+01:00" CHECKSUM="F24263BF09994749F335E1664DCE0086DB6DCA323FDB6996938BCD28EA9E8153" CHECKSUMTYPE="SHA-256"/>
+        </mets:dmdSec>
+    </Example>
+    <Example ID="amdSecExample1" LABEL="METS example of references to preservation metadata in the form of PREMIS metadata for describing the preservation objects and the events pertaining to the objects">
+        <mets:amdSec>
+            <mets:digiprovMD ID="digiprov-premis-file-1" CREATED="2018-04-24T14:37:52.783+01:00">
+                <mets:mdRef LOCTYPE="URL" xlink:type="simple" xlink:href="metadata/preservation/premis1.xml" MDTYPE="PREMIS" MDTYPEVERSION="3.0" MIMETYPE="text/xml" SIZE="1211" CREATED="2018-04-24T14:37:52.783+01:00" CHECKSUM="8aa278038dbad54bbf142e7d72b493e2598a94946ea1304dc82a79c6b4bac3d5" CHECKSUMTYPE="SHA-256" LABEL="premis1.xml"/>
+            </mets:digiprovMD>
+            <mets:digiprovMD ID="digiprov-premis-file-2" CREATED="2018-04-24T14:47:52.783+01:00">
+                <mets:mdRef LOCTYPE="URL" xlink:type="simple" xlink:href="metadata/preservation/premis2.xml" MDTYPE="PREMIS" MDTYPEVERSION="3.0" MIMETYPE="text/xml" SIZE="2854" CREATED="2018-04-24T14:37:52.783+01:00" CHECKSUM="d1dfa585dcc9d87268069dc58d5e47956434ec3db4087a75a3885d287f15126f" CHECKSUMTYPE="SHA-256" LABEL="premis2.xml"/>
+            </mets:digiprovMD>
+        </mets:amdSec>
+    </Example>
+    <Example ID="fileSecExample1" LABEL="METS example of how the structuring of the data is made in the file section">
+        <mets:fileSec ID="file-sec-example">
+            <!-- Main grouping starting names is Documentation, Schemas and Representations can be mirrored in the folder names-->
+            <mets:fileGrp ID="file-grp-doc" USE="Documentation">
+                <!-- Documentation is grouped in one or more fileGrp with the use being the path to the documentation -->
+                <mets:file ID="file-docx" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="documentation/File.docx"/>
+                </mets:file>
+                <mets:file ID="file2-docx" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="documentation/File2.docx"/>
+                </mets:file>
+            </mets:fileGrp>
+            <mets:fileGrp ID="file-grp-schema" USE="Schemas">
+                <!-- XML-schemas is grouped in one or more fileGrp with the use being the path to the documentation -->
+                <mets:file ID="file-ead-schema" MIMETYPE="text/xsd" SIZE="123917" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="0BF9E16ADE296EF277C7B8E5D249D300F1E1EB59F2DCBD89644B676D66F72DCC" CHECKSUMTYPE="SHA-256">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="schemas/ead2002.xsd"/>
+                </mets:file>
+            </mets:fileGrp>
+            <mets:fileGrp ID="file-grp-rep-subdata" USE="Representations/submission/data" csip:CONTENTINFORMATIONTYPE="SIARDDK">
+                <!-- The fileGrp USE attribute gives the folder name including path to the where the data is found -->
+                <!-- All transferred data is stored in a folder, the filepath is shown in the href -->
+                <mets:file ID="file-siard-xml" MIMETYPE="xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="digiprov-premis-file-2 digiprov-premis-file-1">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/submission/data/SIARD.xml"/>
+                </mets:file>
+            </mets:fileGrp>
+        </mets:fileSec>
+    </Example>
+    <Example ID="fileSecExample2" LABEL="METS example of how the structuring of the data including representations are made in the file section">
+            <!-- The fileGrp USE attribute gives the folder name including path to the where the data is found -->
+        <mets:fileSec ID="file-sec-example">
+            <!-- Main grouping starting names is Documetation, Schemas and Representations can be mirrored in the folder names-->
+            <mets:fileGrp ID="file-grp-doc" USE="Documentation">
+                <!-- Documentation is grouped in one or more fileGrp with the use being the path to the documentation -->
+                <!-- This documentation is for the whole package, the representations documentation is described in the mets for the representation -->
+                <mets:file ID="file-docx" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="documentation/File.docx"/>
+                </mets:file>
+                <mets:file ID="file2-docx" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="documentation/File2.docx"/>
+                </mets:file>
+            </mets:fileGrp>
+            <mets:fileGrp ID="file-grp-schema" USE="Schemas">
+                <!-- XML-schemas is grouped in one or more fileGrp with the use being the path to the documentation -->
+                <mets:file ID="file-ead-schema" MIMETYPE="text/xsd" SIZE="123917" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="0BF9E16ADE296EF277C7B8E5D249D300F1E1EB59F2DCBD89644B676D66F72DCC" CHECKSUMTYPE="SHA-256">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="schemas/ead2002.xsd"/>
+                </mets:file>
+            </mets:fileGrp>
+            <!-- All transferred data is stored in a folder, the filepath is shown in the href -->
+            <!-- For each representation the file referenced in the file group is the representation METS document -->
+            <mets:fileGrp ID="file-grp-rep-preing" USE="Representations/preingest" csip:CONTENTINFORMATIONTYPE="OTHER" csip:OTHERCONTENTINFORMATIONTYPE="Access database">
+                <mets:file ID="file-preing-mets-xml" MIMETYPE="xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="digiprov-premis-file-2 digiprov-premis-file-1">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/preingest/METS.xml"/>
+                </mets:file>
+            </mets:fileGrp>
+            <mets:fileGrp ID="file-grp-rep-sub" USE="Representations/submission" csip:CONTENTINFORMATIONTYPE="SIARDDK" ADMID="digiprov-premis-file-1 digiprov-premis-file-2">
+                <mets:file ID="file-sub-mets-xml" MIMETYPE="application/xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="digiprov-premis-file-2 digiprov-premis-file-1">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/submission/METS.xml"/>
+                </mets:file>
+            </mets:fileGrp>
+            <mets:fileGrp ID="file-grp-rep-ing" USE="Representations/ingest" csip:CONTENTINFORMATIONTYPE="SIARD1" ADMID="digiprov-premis-file-3 digiprov-premis-file-4">
+                <mets:file ID="file-ing-mets-xml" MIMETYPE="application/xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="digiprov-premis-file-2 digiprov-premis-file-1">
+                    <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/ingest/METS.xml"/>
+                </mets:file>
+            </mets:fileGrp>
+        </mets:fileSec>
+    </Example>
+    <Example ID="structMapExample1" LABEL="METS example of the mandatory structural map">
+        <mets:structMap ID="struct-map-example-1" TYPE="PHYSICAL" LABEL="CSIP">
+            <mets:div ID="struct-map-example-div" LABEL="csip-mets-example">
+                <mets:div ID="struct-map-metadata-div" LABEL="Metadata" ADMID="digiprov-premis-file-1 digiprov-premis-file-2" DMDID="dmd-ead-file"/>
+                <mets:div ID="struct-map-doc-div" LABEL="Documentation">
+                    <mets:fptr FILEID="file-ptr-doc"/>
+                </mets:div>
+                <mets:div ID="struct-map-schema-div" LABEL="Schemas">
+                    <mets:fptr FILEID="file-grp-schema"/>
+                </mets:div>
+                <mets:div ID="struct-map-reps-sub-div" LABEL="Representations">
+                    <mets:fptr FILEID="file-grp-rep-subdata"/>
+                </mets:div>
+            </mets:div>
+        </mets:structMap>
+    </Example>
+    <Example ID="structMapExample2" LABEL="METS example of the mandatory structural map including representations">
+        <mets:structMap ID="struct-map-example-1" TYPE="PHYSICAL" LABEL="CSIP">
+            <mets:div ID="struct-map-example-div" LABEL="csip-mets-example">
+               <mets:div ID="struct-map-metadata-div" LABEL="Metadata" ADMID="digiprov-premis-file-1 digiprov-premis-file-2 digiprov-premis-file-3 digiprov-premis-file-4" DMDID="dmd-ead-file"/>
+                <mets:div ID="struct-map-schema-div" LABEL="Schemas">
+                    <mets:fptr FILEID="file-ptr-schema"/>
+                </mets:div>
+                <!-- mptr Only present if representations is transferred and gives all the linked mets documents-->
+                <mets:div ID="struct-map-reps-preing-div" LABEL="Representations/preingest">
+                    <mets:mptr LOCTYPE="URL" xlink:type="simple" xlink:href="representations/preingest/METS.xml" xlink:title="file-grp-rep-preing"/>
+                </mets:div>
+                <mets:div ID="struct-map-reps-sub-div" LABEL="Representations/submission">
+                    <mets:mptr LOCTYPE="URL" xlink:type="simple" xlink:href="representations/submission/METS.xml" xlink:title="file-grp-rep-sub"/>
+                </mets:div>
+                <mets:div ID="struct-map-reps-ing-div" LABEL="Representations/ingest">
+                    <mets:mptr LOCTYPE="URL" xlink:type="simple" xlink:href="representations/ingest/METS.xml" xlink:title="file-grp-rep-ing"/>
+                </mets:div>
+            </mets:div>
+        </mets:structMap>
+    </Example>
+    <Appendix NUMBER="1" LABEL="Example of a whole METS document describing an information package with no representations">
+        <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:mets="http://www.loc.gov/METS/"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
+            OBJID="csip-mets-example"
+            LABEL="Sample CSIP Information Package with no representations"
+            TYPE="Database"
+            csip:CONTENTINFORMATIONTYPE="SIARDDK"
+            PROFILE="https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml"
+            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
+            <mets:metsHdr CREATEDATE="2018-04-24T14:37:49.602+01:00" LASTMODDATE="2018-04-24T14:37:49.602+01:00" RECORDSTATUS="NEW" csip:OAISPACKAGETYPE="SIP">
+                <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
+                    <mets:name>RODA-in</mets:name>
+                    <mets:note csip:NOTETYPE="SOFTWARE VERSION">2.1.0-beta.7</mets:note>
+                </mets:agent>
+            </mets:metsHdr>
+            <mets:dmdSec ID="appdx1.dmd-ead-file" CREATED="2018-04-24T14:37:49.609+01:00">
+                <mets:mdRef LOCTYPE="URL" MDTYPE="EAD" MDTYPEVERSION="2002" xlink:type="simple"  xlink:href="metadata/descriptive/ead2002.xml" SIZE="903" CREATED="2018-04-24T14:37:49.609+01:00" CHECKSUM="F24263BF09994749F335E1664DCE0086DB6DCA323FDB6996938BCD28EA9E8153" CHECKSUMTYPE="SHA-256"/>
+            </mets:dmdSec>
+            <mets:amdSec>
+                <mets:digiprovMD ID="appdx1.digiprov-premis-file-1" CREATED="2018-04-24T14:37:52.783+01:00">
+                    <mets:mdRef LOCTYPE="URL" xlink:type="simple" xlink:href="metadata/preservation/premis1.xml" MDTYPE="PREMIS" MDTYPEVERSION="3.0" MIMETYPE="text/xml" SIZE="1211" CREATED="2018-04-24T14:37:52.783+01:00" CHECKSUM="8aa278038dbad54bbf142e7d72b493e2598a94946ea1304dc82a79c6b4bac3d5" CHECKSUMTYPE="SHA-256" LABEL="premis1.xml"/>
+                </mets:digiprovMD>
+                <mets:digiprovMD ID="appdx1.digiprov-premis-file-2" CREATED="2018-04-24T14:47:52.783+01:00">
+                    <mets:mdRef LOCTYPE="URL" xlink:type="simple" xlink:href="metadata/preservation/premis2.xml" MDTYPE="PREMIS" MDTYPEVERSION="3.0" MIMETYPE="text/xml" SIZE="2854" CREATED="2018-04-24T14:37:52.783+01:00" CHECKSUM="d1dfa585dcc9d87268069dc58d5e47956434ec3db4087a75a3885d287f15126f" CHECKSUMTYPE="SHA-256" LABEL="premis2.xml"/>
+                </mets:digiprovMD>
+            </mets:amdSec>
+            <mets:fileSec ID="appdx1.file-sec-example">
+                <mets:fileGrp ID="appdx1.file-grp-doc" USE="Documentation">
+                    <mets:file ID="appdx1.file-docx" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="documentation/File.docx"/>
+                    </mets:file>
+                    <mets:file ID="appdx1.file2-docx" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="documentation/File2.docx"/>
+                    </mets:file>
+                </mets:fileGrp>
+                <mets:fileGrp ID="appdx1.file-grp-schema" USE="Schemas">
+                    <mets:file ID="appdx1.file-ead-schema" MIMETYPE="text/xsd" SIZE="123917" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="0BF9E16ADE296EF277C7B8E5D249D300F1E1EB59F2DCBD89644B676D66F72DCC" CHECKSUMTYPE="SHA-256">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="schemas/ead2002.xsd"/>
+                    </mets:file>
+                </mets:fileGrp>
+                <mets:fileGrp ID="appdx1.file-grp-rep-subdata" USE="Representations/Submission/Data" csip:CONTENTINFORMATIONTYPE="SIARDDK">
+                    <mets:file ID="appdx1.file-siard-xml" MIMETYPE="xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="appdx1.digiprov-premis-file-2 appdx1.digiprov-premis-file-1">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/submission/data/SIARD.xml"/>
+                    </mets:file>
+                </mets:fileGrp>
+            </mets:fileSec>
+            <mets:structMap ID="appdx1.struct-map-example-1" TYPE="PHYSICAL" LABEL="CSIP">
+                <mets:div ID="appdx1.struct-map-example-div" LABEL="csip-mets-example">
+                    <mets:div ID="appdx1.struct-map-metadata-div" LABEL="Metadata" ADMID="appdx1.digiprov-premis-file-1 appdx1.digiprov-premis-file-2" DMDID="appdx1.dmd-ead-file"/>
+                    <mets:div ID="appdx1.struct-map-doc-div" LABEL="Documentation">
+                        <mets:fptr FILEID="appdx1.file-grp-doc"/>
+                    </mets:div>
+                    <mets:div ID="appdx1.struct-map-schema-div" LABEL="Schemas">
+                        <mets:fptr FILEID="appdx1.file-grp-schema"/>
+                    </mets:div>
+                    <mets:div ID="appdx1.struct-map-reps-sub-div" LABEL="Representations">
+                        <mets:fptr FILEID="appdx1.file-grp-rep-subdata"/>
+                    </mets:div>
+                </mets:div>
+            </mets:structMap>
+        </mets:mets>
+    </Appendix>
+    <Appendix NUMBER="2" LABEL="Example of a whole METS document describing an information package with representations">
+        <mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:mets="http://www.loc.gov/METS/"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"
+            OBJID="csip-mets-example"
+            LABEL="Sample CSIP Information Package with representations"
+            TYPE="Database"
+            PROFILE="https://earkcsip.dilcis.eu/profile/E-ARK-CSIP.xml"
+            xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd">
+            <mets:metsHdr CREATEDATE="2018-04-24T14:37:49.602+01:00" LASTMODDATE="2018-04-24T14:37:49.602+01:00" RECORDSTATUS="NEW" csip:OAISPACKAGETYPE="SIP">
+                <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
+                    <mets:name>RODA-in</mets:name>
+                    <mets:note csip:NOTETYPE="SOFTWARE VERSION">2.1.0-beta.7</mets:note>
+                </mets:agent>
+            </mets:metsHdr>
+            <mets:dmdSec ID="appdx2.dmd-ead-file" CREATED="2018-04-24T14:37:49.609+01:00">
+                <!-- Archival description on the highest level pertaining to the whole package -->
+                <mets:mdRef LOCTYPE="URL" MDTYPE="EAD" MDTYPEVERSION="2002" xlink:type="simple"  xlink:href="metadata/descriptive/ead2002.xml" SIZE="903" CREATED="2018-04-24T14:37:49.609+01:00" CHECKSUM="F24263BF09994749F335E1664DCE0086DB6DCA323FDB6996938BCD28EA9E8153" CHECKSUMTYPE="SHA-256"/>
+            </mets:dmdSec>
+            <mets:amdSec>
+                <!-- Administritive metadata pertaining to the whole package and its representations -->
+                <!-- PREMIS information relating to the creation of the SIARDDK of the Access database -->
+                <mets:digiprovMD ID="appdx2.digiprov-premis-file-1" CREATED="2018-04-24T14:37:52.783+01:00">
+                    <mets:mdRef LOCTYPE="URL" xlink:type="simple" xlink:href="metadata/preservation/premis1.xml" MDTYPE="PREMIS" MDTYPEVERSION="3.0" MIMETYPE="text/xml" SIZE="1211" CREATED="2018-04-24T14:37:52.783+01:00" CHECKSUM="8aa278038dbad54bbf142e7d72b493e2598a94946ea1304dc82a79c6b4bac3d5" CHECKSUMTYPE="SHA-256" LABEL="premis1.xml"/>
+                </mets:digiprovMD>
+                <mets:digiprovMD ID="appdx2.digiprov-premis-file-2" CREATED="2018-04-24T14:47:52.783+01:00">
+                    <mets:mdRef LOCTYPE="URL" xlink:type="simple" xlink:href="metadata/preservation/premis2.xml" MDTYPE="PREMIS" MDTYPEVERSION="3.0" MIMETYPE="text/xml" SIZE="2854" CREATED="2018-04-24T14:37:52.783+01:00" CHECKSUM="d1dfa585dcc9d87268069dc58d5e47956434ec3db4087a75a3885d287f15126f" CHECKSUMTYPE="SHA-256" LABEL="premis2.xml"/>
+                </mets:digiprovMD>
+                <!-- PREMIS information relating to the creation of the SIARD1 of the SIARDDK -->
+                <mets:digiprovMD ID="appdx2.digiprov-premis-file-3" CREATED="2018-04-24T14:37:52.783+01:00">
+                    <mets:mdRef LOCTYPE="URL" xlink:type="simple" xlink:href="metadata/preservation/premis3.xml" MDTYPE="PREMIS" MDTYPEVERSION="3.0" MIMETYPE="text/xml" SIZE="1211" CREATED="2018-04-24T14:37:52.783+01:00" CHECKSUM="8aa278038dbad54bbf142e7d72b493e2598a94946ea1304dc82a79c6b4bac3d5" CHECKSUMTYPE="SHA-256" LABEL="premis1.xml"/>
+                </mets:digiprovMD>
+                <mets:digiprovMD ID="appdx2.digiprov-premis-file-4" CREATED="2018-04-24T14:47:52.783+01:00">
+                    <mets:mdRef LOCTYPE="URL" xlink:type="simple" xlink:href="metadata/preservation/premis4.xml" MDTYPE="PREMIS" MDTYPEVERSION="3.0" MIMETYPE="text/xml" SIZE="2854" CREATED="2018-04-24T14:37:52.783+01:00" CHECKSUM="d1dfa585dcc9d87268069dc58d5e47956434ec3db4087a75a3885d287f15126f" CHECKSUMTYPE="SHA-256" LABEL="premis2.xml"/>
+                </mets:digiprovMD>
+            </mets:amdSec>
+            <mets:fileSec ID="appdx2.file-sec-example">
+                <mets:fileGrp ID="appdx2.file-grp-doc" USE="Documentation">
+                    <mets:file ID="appdx2.file-docx" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="documentation/File.docx"/>
+                    </mets:file>
+                    <mets:file ID="appdx2.file2-docx" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="documentation/File2.docx"/>
+                    </mets:file>
+                </mets:fileGrp>
+                <mets:fileGrp ID="appdx2.file-grp-schema" USE="Schemas">
+                    <mets:file ID="appdx2.file-ead-schema" MIMETYPE="text/xsd" SIZE="123917" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="0BF9E16ADE296EF277C7B8E5D249D300F1E1EB59F2DCBD89644B676D66F72DCC" CHECKSUMTYPE="SHA-256">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="schemas/ead2002.xsd"/>
+                    </mets:file>
+                </mets:fileGrp>
+                <mets:fileGrp ID="appdx2.file-grp-rep-preing" USE="Representations/preingest" csip:CONTENTINFORMATIONTYPE="OTHER">
+                    <mets:file ID="appdx2.file-preing-mets-xml" MIMETYPE="xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="appdx2.digiprov-premis-file-2 appdx2.digiprov-premis-file-1">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/preingest/METS.xml"/>
+                    </mets:file>
+                </mets:fileGrp>
+                <mets:fileGrp ID="appdx2.file-grp-rep-sub" USE="Representations/submission" csip:CONTENTINFORMATIONTYPE="SIARDDK" ADMID="appdx2.digiprov-premis-file-1 appdx2.digiprov-premis-file-2">
+                    <mets:file ID="appdx2.file-sub-mets-xml" MIMETYPE="application/xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="appdx2.digiprov-premis-file-2 appdx2.digiprov-premis-file-1">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/submission/METS.xml"/>
+                    </mets:file>
+                </mets:fileGrp>
+                <mets:fileGrp ID="appdx2.file-grp-rep-ing" USE="Representations/ingest" csip:CONTENTINFORMATIONTYPE="SIARD1" ADMID="appdx2.digiprov-premis-file-3 appdx2.digiprov-premis-file-4">
+                    <mets:file ID="appdx2.file-ing-mets-xml" MIMETYPE="application/xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="appdx2.digiprov-premis-file-2 appdx2.digiprov-premis-file-1">
+                        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/ingest/METS.xml"/>
+                    </mets:file>
+                </mets:fileGrp>
+            </mets:fileSec>
+            <mets:structMap ID="appdx2.struct-map-example-1" TYPE="PHYSICAL" LABEL="CSIP">
+                <mets:div ID="appdx2.struct-map-example-div" LABEL="csip-mets-example">
+                    <mets:div ID="appdx2.struct-map-metadata-div" LABEL="Metadata" ADMID="appdx2.digiprov-premis-file-1 appdx2.digiprov-premis-file-2 appdx2.digiprov-premis-file-3 appdx2.digiprov-premis-file-4" DMDID="appdx2.dmd-ead-file"/>
+                    <mets:div ID="appdx2.struct-map-schema-div" LABEL="Schemas">
+                        <mets:fptr FILEID="appdx2.file-grp-schema"/>
+                    </mets:div>
+                    <mets:div ID="appdx2.struct-map-reps-preing-div" LABEL="Representations/preingest">
+                        <mets:mptr LOCTYPE="URL" xlink:type="simple" xlink:href="representations/preingest/METS.xml" xlink:title="file-grp-rep-preing"/>
+                    </mets:div>
+                    <mets:div ID="appdx2.struct-map-reps-sub-div" LABEL="Representations/submission">
+                        <mets:mptr LOCTYPE="URL" xlink:type="simple" xlink:href="representations/submission/METS.xml" xlink:title="file-grp-rep-sub"/>
+                    </mets:div>
+                    <mets:div ID="appdx2.struct-map-reps-ing-div" LABEL="Representations/ingest">
+                        <mets:mptr LOCTYPE="URL" xlink:type="simple" xlink:href="representations/ingest/METS.xml" xlink:title="file-grp-rep-ing"/>
+                    </mets:div>
+                </mets:div>
+            </mets:structMap>
+        </mets:mets>
+    </Appendix>
+</METS_Profile>

--- a/profile/E-ARK-CSIP-v2-1-1.xml
+++ b/profile/E-ARK-CSIP-v2-1-1.xml
@@ -156,41 +156,95 @@
                     <head>Package Identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The `mets/@OBJID` attribute is mandatory, its value is a string identifier for the METS document. For the package METS document, this should be the name/ID of the package, i.e. the name of the package root folder.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">For a representation level METS document this value records the name/ID of the representation, i.e. the name of the top-level representation folder.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/@OBJID</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST1-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testWrap>
+                            <!--as far as my understanding goes, this XPATH wouldn't evaluate correctly in practice without the mets namespace prefix, though I could certainly be incorrect and it might need to be pruned in the interpolation to the published PDF-->
+                            <testXML>mets/@OBJID</testXML>
+                        </testWrap>
+                    </test>
+                    <test ID="TEST1-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <!--the schematron test expressed in the python validator goes simply @OBJID, of course being the root element a count of one is implied but to make it implicit in the test I have modified to include a count, may require discussion-->
+                                    <!--NB precedent for this is the proposed interpolation of CSIP10, pyvalidator schematron tests plainly for mets:agent proposed profile test adds cardinality test-->
+                                    <iso:assert id="CSIP1" role="ERROR" test="count(@OBJID)=1">The mets/@OBJID attribute is mandatory, its value is a string identifier for the METS document. For the package METS document, this should be the name/ID of the package, i.e. the name of the package root folder. For a representation level METS document this value records the name/ID of the representation, i.e. the name of the top-level representation folder.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP2" REQLEVEL="MUST" RELATEDMAT="VocabularyContentCategory" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                 <description>
                     <head>Content Category</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The `mets/@TYPE` attribute MUST be used to declare the category of the content held in the package, e.g. "Datasets", "Websites", "Mixes" , "Other", etc.. Legal values are defined in a fixed vocabulary. When the content category used falls outside of the defined vocabulary the `mets/@TYPE` value must be set to "OTHER" and the specific value declared in `mets/@csip:OTHERTYPE`. The vocabulary will develop under the curation of the DILCIS Board as additional content information type specifications are produced.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/@TYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST2-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testWrap>
+                            <testXML>mets/@TYPE</testXML>
+                        </testWrap>
+                    </test>
+                    <test ID="TEST2-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <!--ignoring the issue raised with casing incogruity-->
+                                    <iso:assert id="CSIP2" role="ERROR" test="count(@TYPE)=1">The mets/@TYPE attibute MUST be used to declare the category of the content held in the package, e.g. book, journal, stereograph, video, etc.. Legal values are defined in a fixed vocabulary.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP3" REQLEVEL="SHOULD" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                 <description>
                     <head>Other Content Category</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/@TYPE` attribute has the value "OTHER" the `mets/@csip:OTHERTYPE` attribute MUST be used to declare the content category of the package/representation. The value can either be "OTHER" or any other string that are not present in the vocabulary used in the `mets/@TYPE` attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets[@TYPE='OTHER']/@csip:OTHERTYPE</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST3-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testWrap>
+                            <!--case of the 'other' casing issue, as such I am leaving this alone for now-->
+                            <testXML>mets[@TYPE='OTHER']/@csip:OTHERTYPE</testXML>
+                        </testWrap>
+                    </test>
+                    <test ID="TEST3-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="">
+                                    <!--I have made cardinality implicit in this test (modified from pyvalidator), but it could be confusing because of the 'should conditional must' situation. It's probably best to discuss this-->
+                                    <iso:assert id="CSIP3" role="WARN" test="(@TYPE = 'OTHER' and count(@csip:OTHERTYPE)=1) or @TYPE != 'OTHER'">When the content category used falls outside of the defined vocabulary the mets/@TYPE value must be set to “OTHER” and the specific value declared in mets/@csip:OTHERTYPE. The vocabulary will develop under the curation of the DILCIS Board as additional content information type specifications are produced.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP4" REQLEVEL="SHOULD" RELATEDMAT="VocabularyContentInformationTypeSpecification" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                <description>
                     <head>Content Information Type Specification</head>
-                   <p xmlns="http://www.w3.org/1999/xhtml">Used to declare the Content Information Type Specification used when creating the package. Legal values are defined in a fixed vocabulary. The attribute is mandatory for representation level METS documents. The vocabulary will evolve under the care of the DILCIS Board as additional Content Information Type Specifications are developed.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/@csip:CONTENTINFORMATIONTYPE</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Used to declare the Content Information Type Specification used when creating the package. Legal values are defined in a fixed vocabulary. The attribute is mandatory for representation level METS documents. The vocabulary will evolve under the care of the DILCIS Board as additional Content Information Type Specifications are developed.</p>
                 </description>
+                <tests>
+                    <test ID="TEST4-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testWrap>
+                            <testXML>mets/@csip:CONTENTINFORMATIONTYPE</testXML>
+                        </testWrap>
+                    </test>
+                    <test ID="TEST4-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <iso:assert id="CSIP4" role="WARN" test="count(@csip:CONTENTINFORMATIONTYPE)<=1">Used to declare the Content Information Type Specification used when creating the package. Legal values are defined in a fixed vocabulary. The attribute is mandatory for representation level METS documents.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP5" REQLEVEL="MAY" RELATEDMAT="CSIP4" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                 <description>

--- a/profile/E-ARK-CSIP-v2-1-1.xml
+++ b/profile/E-ARK-CSIP-v2-1-1.xml
@@ -1344,61 +1344,125 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">References to all transferred content SHOULD be placed in the file section in the different file group elements, described in other requirements.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Only a single file section (`&lt;fileSec&gt;`) element should be present.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">In the case that a package only contains metadata updates, i.e. exclusively metadata files, then no file references need to be added to this section.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST58-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec</testString>
+                    </test>
+                    <test ID="TEST58-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <iso:assert id="CSIP58" role="WARN" test="mets:fileSec">The transferred content is placed in the file section in different file group elements, described in other requirements.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP59" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File section identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the file section used for internal package references. It must be unique within the package.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/@ID</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST59-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/@ID</testString>
+                    </test>
+                    <test ID="TEST59-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec">
+                                    <iso:assert id="CSIP59" role="ERROR" test="@ID">An xml:id identifier for the file section used for internal package references.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP60" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Documentation file group</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">All documentation pertaining to the transferred content is placed in one or more file group elements with `mets/fileSec/fileGrp/@USE` attribute value "Documentation".</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE='Documentation']</dd>
-                        <dt>Cardinality</dt><dd>1..n</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST60-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp[@USE='Documentation']</testString>
+                    </test>
+                    <test ID="TEST60-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec">
+                                    <iso:assert id="CSIP60" role="ERROR" test="mets:fileGrp[@USE = 'Documentation']">All documentation pertaining to the transferred content is placed in one or more file group elements with mets/fileSec/fileGrp/@USE attribute value “Documentation”.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP113" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Schema file group</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">All XML schemas used in the information package must be referenced from one or more file groups with `mets/fileSec/fileGrp/@USE` attribute value "Schemas".</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE='Schemas']</dd>
-                        <dt>Cardinality</dt><dd>1..n</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST113-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp[@USE='Schemas']</testString>
+                    </test>
+                    <test ID="TEST113-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec">
+                                    <iso:assert id="CSIP113" role="ERROR" test="mets:fileGrp[@USE = 'Schemas']">All XML schemas used in the information package should be referenced from one or more file groups with mets/fileSec/fileGrp/@USE attribute value “Schemas”.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test> 
+                </tests>
             </requirement>
             <requirement ID="CSIP114" REQLEVEL="MUST" RELATEDMAT="VocabularyFileGrpAndStructMapDivisionLabel CSIP64" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Representations file group</head>
+                    <!--instructions on usage of "Representations" value for @USE attribute are unclear-->
                     <p xmlns="http://www.w3.org/1999/xhtml">A pointer to the METS document describing the representation or pointers to the content being transferred must be present in one or more file groups with `mets/fileSec/fileGrp/@USE` attribute value starting with "Representations" followed by the path to the folder where the representation level METS document is placed. For example "Representation/submission" and "Representation/ingest".</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@USE=[starts-with('Representations')]]</dd>
-                        <dt>Cardinality</dt><dd>1..n</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST114-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <!--improper usage of xml function starts-with in original version fixed here-->
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp[starts-with(@USE,'Representations')]</testString>
+                    </test>
+                    <test ID="TEST114-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <!-- the pyvalidator schematron test for CSIP 114 only allows for the @USE attribute value "Representations", the specification calls for affixes to be added-->
+                                <!-- new test, below proposed on github, validation message will also need to be updated-->
+                                <iso:rule context="/mets:mets/mets:fileSec">
+                                    <iso:assert id="CSIP114" role="ERROR" test="mets:fileGrp[starts-with(@USE, 'Representations')]">A pointer to the METS document describing the representation or pointers to the content being transferred must be present in one or more file groups with mets/fileSec/fileGrp/@USE attribute value “Representations”.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP61" REQLEVEL="MAY" RELATEDMAT="CSIP31" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Reference to administrative metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">If administrative metadata has been provided at file group `mets/fileSec/fileGrp` level this attribute refers to its administrative metadata section by ID.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@ADMID</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST61-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/@ADMID</testString>
+                    </test>
+                    <test ID="TEST61-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp">
+                                    <iso:assert id="CSIP61" role="INFO" test="@ADMID">ADMID attribute used.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP62" REQLEVEL="SHOULD" RELATEDMAT="VocabularyContentInformationTypeSpecification CSIP4 CSIP114" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
@@ -1407,181 +1471,365 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">The vocabulary will evolve under the curation of the DILCIS Board as additional content information type specifications are developed.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">When the element "Content Information Type Specification" (CSIP4) has the value "MIXED" or the file group describes a representation, then this element states the content information type specification used for the file group.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">When the element "Representations file group" (CSIP114), the file group describes a representation with the `mets/fileSec/fileGrp/@USE` attribute value is starting with "Representations", then this element must state the content information type specification used for the representation.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/@csip:CONTENTINFORMATIONTYPE="MIXED"|mets/fileSec/fileGrp[@USE=[starts-with('Representations')]]/@csip:CONTENTINFORMATIONTYPE</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST62-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/@csip:CONTENTINFORMATIONTYPE="MIXED"|mets:mets/mets:fileSec/mets:fileGrp[starts-with(@USE, 'Representations')]/@csip:CONTENTINFORMATIONTYPE</testString>
+                    </test>
+                    <test ID="TEST62-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <!-- original pyvalidator schematron does not account for the case of a root mets with the othertype value mixed, a change here requires reducing the context of the test-->
+                                <!-- could be placed by: context="/mets:mets/" test="@csip:CONTENTINFORMATIONTYPE='MIXED' or mets:fileSec/mets:fileGrp[starts-with(@USE, 'Representations')]/@csip:CONTENTINFORMATIONTYPE"-->
+                                <!-- NB this and the original pyvalidator test hardcode an attribute value from a fixed vocab-->
+                                <iso:rule context="/mets:mets/">
+                                    <iso:assert id="CSIP62" role="INFO" test="(@USE = 'Representations' and @csip:CONTENTINFORMATIONTYPE) or @USE != 'Representations'"></iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP63" REQLEVEL="MAY" RELATEDMAT="CSIP62" EXAMPLES="fileSecExample1 fileSecExample2">
+            <!--Only fileSecExample2 seems relevant to this requirement-->
                 <description>
                     <head>Other Content Information Type Specification</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/fileSec/fileGrp/@csip:CONTENTINFORMATIONTYPE` attribute has the value "OTHER" the `mets/fileSec/fileGrp/@csip:OTHERCONTENTINFORMATIONTYPE` must state a value for the Content Information Type Specification used.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp[@csip:CONTENTINFORMATIONTYPE='OTHER']/@csip:OTHERCONTENTINFORMATIONTYPE</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST63-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp[@csip:CONTENTINFORMATIONTYPE='OTHER']/@csip:OTHERCONTENTINFORMATIONTYPE</testString>
+                    </test>
+                    <test ID="TEST63-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp">
+                                    <iso:assert id="CSIP63" role="ERROR" test="(@csip:CONTENTINFORMATIONTYPE = 'OTHER' and @csip:OTHERCONTENTINFORMATIONTYPE) or @csip:CONTENTINFORMATIONTYPE != 'OTHER' or not(@csip:CONTENTINFORMATIONTYPE)"></iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP64" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Description of the use of the file group</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The value in the `mets/fileSec/fileGrp/@USE` is the name of the whole folder structure to the data, e.g "Documentation", "Schemas", "Representations/preingest" or "Representations/submission/data".</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@USE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST64-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/@USE</testString>
+                    </test>
+                    <test ID="TEST64-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp">
+                                    <iso:assert id="CSIP64" role="ERROR" test="@USE">This attribute is mandatory.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP65" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File group identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the file group used for internal package references. It must be unique within the package.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/@ID</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST65-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp</testString>
+                    </test>
+                    <test ID="TEST65-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp">
+                                    <iso:assert id="CSIP65" role="ERROR" test="@ID">This attribute is mandatory. An xml:id identifier for the file group used for internal package references. It must be unique within the package.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP66" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The file group (`&lt;fileGrp&gt;`) contains the file elements which describe the file objects.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file</dd>
-                        <dt>Cardinality</dt><dd>1..n</dd>
-                    </dl>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The file group (`&lt;fileGrp&gt;`) contains the file elements which describe the file objects.</p>   
                 </description>
+                <tests>
+                    <test ID="TEST66-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file</testString>
+                    </test>
+                    <test ID="TEST66-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp">
+                                    <iso:assert id="CSIP66" role="ERROR" test="mets:file">The file group contains the file elements which describe the file objects.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP67" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">A unique `xml:id` identifier for this file across the package.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@ID</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST67-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString></testString>
+                    </test>
+                    <test ID="TEST67-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP67" role="ERROR" test="@ID">This attribute is mandatory. An xml:id identifier for the file group used for internal package references. It must be unique within the package.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP68" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File mimetype</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@MIMETYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST68-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/@MIMETYPE</testString>
+                    </test>
+                    <test ID="TEST68-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP68" role="ERROR" test="@MIMETYPE">MUST record the MIME type of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP69" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File size</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@SIZE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST69-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/@SIZE</testString>
+                    </test>
+                    <test ID="TEST69-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP69" role="ERROR" test="@SIZE">MUST record the size in bytes of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP70" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File creation datetime</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Creation date and time of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CREATED</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST70-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/@CREATED</testString>
+                    </test>
+                    <test ID="TEST70-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP70" role="ERROR" test="@CREATED">MUST record the date the referenced file was created.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP71" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File checksum</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CHECKSUM</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST71-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/@CHECKSUM</testString>
+                    </test>
+                    <test ID="TEST71-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP71" role="ERROR" test="@CHECKSUM">MUST record the checksum of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP72" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File checksum type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">A value from the METS-standard which identifies the algorithm used to calculate the checksum for the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@CHECKSUMTYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST72-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/@CHECKSUMTYPE</testString>
+                    </test>
+                    <test ID="TEST72-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP72" role="ERROR" test="@CHECKSUMTYPE">MUST record the checksum type of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP73" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File original identification</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">If an identifier for the file was supplied by the owner it can be recorded in this attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@OWNERID</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST73-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/@OWNERID</testString>
+                    </test>
+                    <test ID="TEST73-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP73" role="INFO" test="@OWNERID">A file element has an OWNERID attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP74" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File reference to administrative metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">If administrative metadata has been provided for the file this attribute refers to the file's administrative metadata by ID.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@ADMID</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST74-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/@ADMID</testString>
+                    </test>
+                    <test ID="TEST74-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP74" role="INFO" test="">A file element has an ADMID attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP75" REQLEVEL="MAY" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>File reference to descriptive metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">If descriptive metadata has been provided per file this attribute refers to the file's descriptive metadata by ID.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/@DMDID</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST75-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/@DMDID</testString>
+                    </test>
+                    <test ID="TEST75-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP75" role="INFO" test="@DMDID">A file element has an DMDID attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP76" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                <description>
                     <head>File locator reference</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The location of each external file must be defined by the file location `&lt;FLocat&gt;` element using the same rules as references for metadata files. All references to files should be made using the XLink href attribute and the file protocol using the relative location of the file.</p>
-                   <dl xmlns="http://www.w3.org/1999/xhtml">
-                       <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat</dd>
-                       <dt>Cardinality</dt><dd>1..1</dd>
-                   </dl>
                </description>
+               <tests>
+                    <test ID="TEST76-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/mets:FLocat</testString>
+                    </test>
+                    <test ID="TEST76-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file">
+                                    <iso:assert id="CSIP76" role="ERROR" test="mets:FLocat">The location of each external file must be defined by the file location FLocat element.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP77" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat[@LOCTYPE='URL']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST77-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/mets:FLocat[@LOCTYPE='URL']</testString>
+                    </test>
+                    <test ID="TEST77-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file/mets:FLocat">
+                                    <iso:assert id="CSIP77" role="ERROR" test="@LOCTYPE = 'URL'">Mandatory, locator type is always used with the value “URL” from the vocabulary in the attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP78" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Type of link</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat[@xlink:type='simple']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST78-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/mets:FLocat[@xlink:type='simple']</testString>
+                    </test>
+                    <test ID="TEST78-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file/mets:FLocat">
+                                    <iso:assert id="CSIP78" role="ERROR" test="@xlink:type = 'simple'">Attribute MUST be used with the value “simple”. Value list is maintained by the xlink standard.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP79" REQLEVEL="MUST" EXAMPLES="fileSecExample1 fileSecExample2">
                 <description>
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. We  recommend recording a URL type filepath within this attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/fileSec/fileGrp/file/FLocat/@xlink:href</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST79-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:fileSec/mets:fileGrp/mets:file/mets:FLocat/@xlink:href</testString>
+                    </test>
+                    <test ID="TEST79-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:fileSec/mets:fileGrp/mets:file/mets:FLocat">
+                                    <iso:assert id="CSIP79" role="ERROR" test="@xlink:href">MUST record the actual location of the resource. This specification recommends recording a URL type filepath within this attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
         </fileSec>
         <structMap ID="structMapElement">
@@ -1592,42 +1840,82 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">The `&lt;structMap&gt;` in the CSIP describes the highest logical structure of the IP.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Every CSIP compliant METS file must include ONE structural map `&lt;structMap&gt;` element used exactly as described in this section of requirements.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Institutions can add their own additional custom structural maps as separate `&lt;structMap&gt;` sections following their own requirements.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/structMap</dd>
-                        <dt>Cardinality</dt><dd>1..n</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST80-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:structMap</testString>
+                    </test>
+                    <test ID="TEST80-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <iso:assert id="CSIP80" role="ERROR" test="mets:structMap">Each METS file must include ONE structural map structMap element used exactly as described here.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP81" REQLEVEL="MUST" RELATEDMAT="VocabularyStructMapType" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Type of structural description</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The `mets/structMap/@TYPE` attribute must take the value “PHYSICAL” from the vocabulary.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/structMap[@TYPE='PHYSICAL']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST81-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:structMap[@TYPE = 'PHYSICAL']</testString>
+                    </test>
+                    <test ID="TEST81-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:structMap">
+                                    <iso:assert id="CSIP81" role="ERROR" test="@TYPE = 'PHYSICAL'">The mets/structMap/@TYPE attribute must take the value “PHYSICAL” from the vocabulary.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP82" REQLEVEL="MUST" RELATEDMAT="VocabularyStructMapLabel" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Name of the structural description</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The `mets/structMap/@LABEL` attribute value is set to “CSIP” from the vocabulary.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">This requirement identifies the CSIP compliant structural map `&lt;structMap&gt;` element.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST82-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:structMap[@LABEL='CSIP']</testString>
+                    </test>
+                    <test ID="TEST82-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:structMap">
+                                    <iso:assert id="CSIP82" role="ERROR" test="@LABEL = 'CSIP'">The mets/structMap/@LABEL attribute value is set to “CSIP” from the vocabulary.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP83" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>
                     <head>Structural description identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the structural description (structMap) used for internal package references. It must be unique within the package.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/structMap[@LABEL='CSIP']/@ID</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST83-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:structMap[@LABEL='CSIP']/@ID</testString>
+                    </test>
+                    <test ID="TEST83-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:structMap[@LABEL='CSIP']">
+                                    <iso:assert id="CSIP83" role="ERROR" test="@ID">An xml:id identifier for the structural description (structMap) used for internal package references. It must be unique within the package.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP84" REQLEVEL="MUST" EXAMPLES="structMapExample1 structMapExample2">
                 <description>

--- a/profile/E-ARK-CSIP-v2-1-1.xml
+++ b/profile/E-ARK-CSIP-v2-1-1.xml
@@ -507,141 +507,286 @@
                     <head>Descriptive metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Must be used if descriptive metadata for the package content is available. Each descriptive metadata section (`&lt;dmdSec&gt;`) contains a single description and must be repeated for multiple descriptions, when available.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">It is possible to transfer metadata in a package using just the descriptive metadata section and/or administrative metadata section.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec</dd>
-                        <dt>Cardinality</dt><dd>0..n</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST17-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec</testString>
+                    </test>
+                    <test ID="TEST17-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <!--Conditional must, difficult to test with no fixed dmd schema, inferring cardinality will be interesting-->
+                                    <iso:assert id="CSIP17" role="WARN" test="mets:dmdSec">Must be used if descriptive metadata about the package content is available. NOTE: According to official METS documentation each metadata section must describe one and only one set of metadata. As such, if implementers want to include multiple occurrences of descriptive metadata into the package this must be done by repeating the whole dmdSec element for each individual metadata.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP18" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Descriptive metadata identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the descriptive metadata section (`&lt;dmdSec&gt;`) used for internal package references. It must be unique within the package.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/@ID</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST18-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/@ID</testString>
+                    </test>
+                    <test ID="TEST18-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec">
+                                    <iso:assert id="CSIP18" role="ERROR" test="@ID">Mandatory, identifier must be unique within the package.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP19" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Descriptive metadata creation datetime</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Creation date and time of the descriptive metadata in this section.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/@CREATED</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST19-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/@CREATED</testString>
+                    </test>
+                    <test ID="TEST19-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec">
+                                    <iso:assert id="CSIP19" role="ERROR" test="@CREATED">Mandatory, creation date of the descriptive metadata in this section.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP20" REQLEVEL="SHOULD" RELATEDMAT="VocabularyStatus" EXAMPLES="dmdSecExample1">
+                <!--The dmdSec element in dmdSecExample1 does not contain an @STATUS attribute-->
                 <description>
                     <head>Status of the descriptive metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/@STATUS</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST20-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/@STATUS</testString>
+                    </test>
+                    <test ID="TEST20-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec">
+                                    <!-- Doesn't implement fixed vocab-->
+                                    <iso:assert id="CSIP20" role="WARN" test="@STATUS">SHOULD be used to indicated the status of the package.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP21" REQLEVEL="SHOULD" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Reference to the document with the descriptive metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Reference to the descriptive metadata file located in the “metadata” section of the IP.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST21-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef</testString>
+                    </test>
+                    <test ID="TEST21-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec">
+                                    <!--The pyvalidator schematron test for CSIP21 has a typo in the mdRef element "mdref", I have submitted the change and proactively changed it here-->
+                                    <!--The same typo appears for the context of all mdRef related tests in pyvalidator, updated in all these profile rules-->
+                                    <iso:assert id="CSIP21" role="WARN" test="mets:mdRef">SHOULD provide a reference to the descriptive metadata file located in the “metadata” section of the IP..</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP22" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef[@LOCTYPE='URL']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST22-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef[@LOCTYPE='URL']</testString>
+                    </test>
+                    <test ID="TEST22-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP22" role="ERROR" test="@LOCTYPE='URL">The locator type is always used with the value “URL” from the vocabulary in the attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP23" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Type of link</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef[@xlink:type='simple']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST23-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef[@xlink:type='simple']</testString>
+                    </test>
+                    <test ID="TEST23-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP23" role="ERROR" test="@xlink:type = 'simple'">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP24" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. This specification recommends recording a URL type filepath in this attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@xlink:href</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST24-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef/@xlink:href</testString>
+                    </test>
+                    <test ID="TEST24-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP24" role="ERROR" test="@xlink:href">The actual location of the resource. This specification recommends recording a URL type filepath in this attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP25" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>Type of metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Values are taken from the list provided by the METS.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@MDTYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST25-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef/@MDTYPE</testString>
+                    </test>
+                    <test ID="TEST25-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP25" role="ERROR" test="@MDTYPE">Specifies the type of metadata in the referenced file. Values are taken from the list provided by the METS.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP26" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File mime type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@MIMETYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST26-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef/@MIMETYPE</testString>
+                    </test>
+                    <test ID="TEST26-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP26" role="ERROR" test="@MIMETYPE">MUST hold the IANA mime type of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP27" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File size</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@SIZE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST27-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef/@SIZE</testString>
+                    </test>
+                    <test ID="TEST27-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP27" role="ERROR" test="@SIZE">MUST hold the size of the referenced file in bytes.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP28" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File creation datetime</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The creation date and time of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CREATED</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST28-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef/@CREATED</testString>
+                    </test>
+                    <test ID="TEST28-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP28" role="ERROR" test="@CREATED">MUST hold the creation date of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP29" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File checksum</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CHECKSUM</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST29-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef/@CHECKSUM </testString>
+                    </test>
+                    <test ID="TEST29-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP29" role="ERROR" test="@CHECKSUM">MUST hold the checksum of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP30" REQLEVEL="MUST" EXAMPLES="dmdSecExample1">
                 <description>
                     <head>File checksum type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">A value from the METS-standard which identifies the algorithm used to calculate the checksum for the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/dmdSec/mdRef/@CHECKSUMTYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST30-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:dmdSec/mets:mdRef/@CHECKSUMTYPE</testString>
+                    </test>
+                    <test ID="TEST30-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:dmdSec/mets:mdRef">
+                                    <iso:assert id="CSIP30" role="ERROR" test="@CHECKSUMTYPE">MUST hold the algorithm type of checksum of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
         </dmdSec>
         <amdSec ID="amdSecElement">
@@ -651,273 +796,545 @@
                     <p xmlns="http://www.w3.org/1999/xhtml">If administrative / preservation metadata is available, it must be described using the administrative metadata section (`&lt;amdSec&gt;`) element.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">All administrative metadata is present in a single `&lt;amdSec&gt;` element.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">It is possible to transfer metadata in a package using just the descriptive metadata section and/or administrative metadata section.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST31-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec</testString>
+                    </test>
+                    <test ID="TEST31-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <iso:assert id="CSIP31" role="WARN" test="mets:amdSec">If administrative / preservation metadata is available, it must be described using the administrative metadata section (amdSec) element. All administrative metadata is present in a single amdSec element.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP32" REQLEVEL="SHOULD" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Digital provenance metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">For recording information about preservation the standard PREMIS is used. It is mandatory to include one `&lt;digiprovMD&gt;` element for each piece of PREMIS metadata.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">The use if PREMIS in METS is following the recommendations in <a href="http://www.loc.gov/standards/premis/guidelines2017-premismets.pdf"> the 2017 version of PREMIS in METS Guidelines.</a></p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD</dd>
-                        <dt>Cardinality</dt><dd>0..n</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST32-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD</testString>
+                    </test>
+                    <test ID="TEST32-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <iso:assert id="CSIP32" role="WARN" test="mets:digiprovMD">Sould be used to record information about preservation the standard PREMIS is used.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP33" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Digital provenance metadata identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the digital provenance metadata section `mets/amdSec/digiprovMD` used for internal package references. It must be unique within the package.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/@ID</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST33-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/@ID</testString>
+                    </test>
+                    <test ID="TEST33-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD">
+                                    <iso:assert id="CSIP33" role="ERROR" test="@ID">Mandatory, unique id for the digital provenance.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP34" REQLEVEL="SHOULD" RELATEDMAT="VocabularyStatus" EXAMPLES="amdSecExample1">
+                <!--Like @STATUS examples for dmdSec, amdSecExample1 does not include the @STATUS attribute-->
                <description>
                     <head>Status of the digital provenance metadata</head>
-                   <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
-                   <dl xmlns="http://www.w3.org/1999/xhtml">
-                       <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/@STATUS</dd>
-                       <dt>Cardinality</dt><dd>0..1</dd>
-                   </dl>
+                    <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
                </description>
+               <tests>
+                    <test ID="TEST34-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/@STATUS</testString>
+                    </test>
+                    <test ID="TEST34-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD">
+                                    <iso:assert id="CSIP34" role="WARN" test="@STATUS">Should be used to indicate the status of the package.e</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP35" REQLEVEL="SHOULD" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Reference to the document with the digital provenance metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Reference to the digital provenance metadata file stored in the “metadata” section of the IP.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST35-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef</testString>
+                    </test>
+                    <test ID="TEST35-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD">
+                                    <iso:assert id="CSIP35" role="WARN" test="mets:mdRef">Should provide a reference to the digital provenance metadata file stored in the “metadata” section of the IP.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP36" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef[@LOCTYPE='URL']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST36-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef[@LOCTYPE='URL']</testString>
+                    </test>
+                    <test ID="TEST36-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef">
+                                    <iso:assert id="CSIP36" role="ERROR" test="@LOCTYPE = 'URL'">Mandatory, locator type is always used with the value “URL” from the vocabulary in the attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP37" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Type of link</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef[@xlink:type='simple']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST37-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef[@xlink:type='simple']</testString>
+                    </test>
+                    <test ID="TEST37-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef">
+                                    <iso:assert id="CSIP37" role="ERROR" test="@xlink:type = 'simple'">Attribute MUST be used with the value “simple”. Value list is maintained by the xlink standard.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP38" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. This specification recommends recording a URL type filepath within this attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@xlink:href</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST38-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef/@xlink:href</testString>
+                    </test>
+                    <test ID="TEST38-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef">
+                                    <iso:assert id="CSIP38" role="ERROR" test="@xhlink:href">MUST record the actual location of the resource. This specification recommends recording a URL type filepath within this attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP39" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Type of metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Values are taken from the list provided by the METS.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@MDTYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST39-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef/@MDTYPE</testString>
+                    </test>
+                    <test ID="TEST39-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef">
+                                    <iso:assert id="CSIP39" role="ERROR" test="@MDTYPE">MUST record the type of metadata at the referenced location.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP40" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File mime type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@MIMETYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST40-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef/@MIMETYPE</testString>
+                    </test>
+                    <test ID="TEST40-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef">
+                                    <iso:assert id="CSIP40" role="ERROR" test="@MIMETYPE">MUST record the MIME type of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP41" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File size</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@SIZE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST41-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef/@SIZE</testString>
+                    </test>
+                    <test ID="TEST41-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef">
+                                    <iso:assert id="CSIP41" role="ERROR" test="@SIZE">MUST record the size in bytes of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP42" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File creation datetime</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Creation date and time of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CREATED</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST42-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef/@CREATED</testString>
+                    </test>
+                    <test ID="TEST42-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef">
+                                    <iso:assert id="CSIP42" role="ERROR" test="@CREATED">MUST record the date the referenced file was created.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP43" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File checksum</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CHECKSUM</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST43-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef/@CHECKSUM</testString>
+                    </test>
+                    <test ID="TEST43-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef">
+                                    <iso:assert id="CSIP43" role="ERROR" test="@CHECKSUM">MUST record the checksum of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP44" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File checksum type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">A value from the METS-standard which identifies the algorithm used to calculate the checksum for the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/digiprovMD/mdRef/@CHECKSUMTYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST44-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:digiprovMD/mets:mdRef/@CHECKSUMTYPE</testString>
+                    </test>
+                    <test ID="TEST44-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="">
+                                    <iso:assert id="CSIP44" role="ERROR" test="@CHECKSUMTYPE">MUST record the checksum type of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP45" REQLEVEL="MAY" EXAMPLES="amdSecExample1">
+                <!--amdSecExample1 does not include any rightsMD elements. This nullifies the listed examples for all requirements that depend on rightsMD. 45 to 56.-->
                 <description>
                     <head>Rights metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">A simple rights statement may be used to describe general permissions for the package. Individual representations should state their specific rights in their representation METS file.</p>
                     <p xmlns="http://www.w3.org/1999/xhtml">Available standards include <a href="http://rightsstatements.org">RightsStatements.org</a>, <a href="https://pro.europeana.eu/page/available-rights-statements">Europeana rights statements info</a>, <a href="https://github.com/mets/METS-Rights-Schema">METS Rights Schema</a> created and maintained by the METS Board, the rights part of <a href="http://www.loc.gov/standards/premis/">PREMIS</a> as well as own local rights statements in use.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD</dd>
-                        <dt>Cardinality</dt><dd>0..n</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST45-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD</testString>
+                    </test>
+                    <test ID="TEST45-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec">
+                                    <iso:assert id="CSIP45" role="INFO" test="mets:rightsMD">A simple rights statement may be used to describe general permissions for the package. Individual representations should state their specific rights in their representation METS file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP46" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Rights metadata identifier</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">An `xml:id` identifier for the rights metadata section (`&lt;rightsMD&gt;`) used for internal package references. It must be unique within the package.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/@ID</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST46-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/@ID</testString>
+                    </test>
+                    <test ID="TEST46-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD">
+                                    <iso:assert id="CSIP46" role="ERROR" test="@ID">Mandatory, unique id for the rights metadata.e</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP47" REQLEVEL="SHOULD" RELATEDMAT="VocabularyStatus" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Status of the rights metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Indicates the status of the package using a fixed vocabulary.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/@STATUS</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST47-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/@STATUS</testString>
+                    </test>
+                    <test ID="TEST47-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD">
+                                    <iso:assert id="CSIP47" role="WARN" test="@STATUS">Should be used to indicate the status of the package.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP48" REQLEVEL="SHOULD" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Reference to the document with the rights metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Reference to the rights metadata file stored in the “metadata” section of the IP.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST48-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef</testString>
+                    </test>
+                    <test ID="TEST48-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD">
+                                    <iso:assert id="CSIP48" role="WARN" test="mets:mdRef">Should provide a reference to the digital provenance metadata file stored in the “metadata” section of the IP.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP49" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The locator type is always used with the value "URL" from the vocabulary in the attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef[@LOCTYPE='URL']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST49-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef[@LOCTYPE='URL']</testString>
+                    </test>
+                    <test ID="TEST49-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef">
+                                    <iso:assert id="CSIP49" role="ERROR" test="@LOCTYPE = 'URL'">Mandatory, locator type is always used with the value “URL” from the vocabulary in the attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP50" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Type of locator</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Attribute used with the value “simple”. Value list is maintained by the xlink standard.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef[@xlink:type='simple']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST50-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef[@xlink:type='simple']</testString>
+                    </test>
+                    <test ID="TEST50-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="">
+                                    <iso:assert id="CSIP50" role="ERROR" test="@xlink:type = 'simple'">Attribute MUST be used with the value “simple”. Value list is maintained by the xlink standard.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP51" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Resource location</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The actual location of the resource. We  recommend recording a URL type filepath within this attribute.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@xlink:href</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST51-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef/@xlink:href</testString>
+                    </test>
+                    <test ID="TEST51-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef">
+                                    <iso:assert id="CSIP51" role="ERROR" test="@xlink:href">MUST record the actual location of the resource. This specification recommends recording a URL type filepath within this attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP52" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>Type of metadata</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Specifies the type of metadata in the referenced file. Value is taken from the list provided by the METS.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@MDTYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST52-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef/@MDTYPE</testString>
+                    </test>
+                    <test ID="TEST52-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef">
+                                    <iso:assert id="CSIP52" role="ERROR" test="@MDTYPE">MUST record the type of metadata at the referenced location.e</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP53" REQLEVEL="MUST" RELATEDMAT="VocabularyIANAmediaTypes" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File mime type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The IANA mime type for the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@MIMETYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST53-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef/@MIMETYPE</testString>
+                    </test>
+                    <test ID="TEST53-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef">
+                                    <iso:assert id="CSIP53" role="ERROR" test="@MIMETYPE">MUST record the MIME type of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP54" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File size</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Size of the referenced file in bytes.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@SIZE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST54-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef/@SIZE</testString>
+                    </test>
+                    <test ID="TEST54-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef">
+                                    <iso:assert id="CSIP54" role="ERROR" test="@SIZE">MUST record the size in bytes of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP55" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File creation datetime </head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Creation date and time of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CREATED</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST55-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef/@CREATED</testString>
+                    </test>
+                    <test ID="TEST55-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef">
+                                    <iso:assert id="CSIP55" role="ERROR" test="@CREATED">MUST record the date the referenced file was created.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP56" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File checksum</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The checksum of the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CHECKSUM</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST56-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef/@CHECKSUM</testString>
+                    </test>
+                    <test ID="TEST56-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef">
+                                    <iso:assert id="CSIP56" role="ERROR" test="@CHECKSUM">MUST record the checksum of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP57" REQLEVEL="MUST" EXAMPLES="amdSecExample1">
                 <description>
                     <head>File checksum type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">A value from the METS-standard which identifies the algorithm used to calculate the checksum for the referenced file.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/amdSec/rightsMD/mdRef/@CHECKSUMTYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST57-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef/@CHECKSUMTYPE</testString>
+                    </test>
+                    <test ID="TEST57-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:amdSec/mets:rightsMD/mets:mdRef">
+                                    <iso:assert id="CSIP57" role="ERROR" test="@CHECKSUMTYPE">MUST record the checksum type of the referenced file.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
         </amdSec>
         <fileSec ID="fileSecElement">

--- a/profile/E-ARK-CSIP-v2-1-1.xml
+++ b/profile/E-ARK-CSIP-v2-1-1.xml
@@ -165,7 +165,7 @@
                         <testWrap>
                             <testXML>
                                 <iso:rule context="/mets:mets">
-                                    <!--combination of assertion role and test evaluation to ascertain cardinality, error+attributeRef = 1..1, warn+attributeRef = 0..1 etc-->
+                                    <!--combination of assertion role, element position and test evaluation to ascertain cardinality, error on root = 1..1, warn on root = 0..1 etc-->
                                     <iso:assert id="CSIP1" role="ERROR" test="@OBJID">The mets/@OBJID attribute is mandatory, its value is a string identifier for the METS document. For the package METS document, this should be the name/ID of the package, i.e. the name of the package root folder. For a representation level METS document this value records the name/ID of the representation, i.e. the name of the top-level representation folder.</iso:assert>
                                 </iso:rule>
                             </testXML>
@@ -284,111 +284,221 @@
                 <description>
                     <head>Package header</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">General element for describing the package.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST117-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr</testString>
+                    </test>
+                    <test ID="TEST117-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <iso:assert id="CSIP117" role="ERROR" test="mets:metsHdr">There MUST be a general element that describes the package.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP7" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Package creation datetime</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@CREATEDATE` records the date and time the package was created.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/@CREATEDATE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST7-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/@CREATEDATE</testString>
+                    </test>
+                    <test ID="TEST7-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr">
+                                    <iso:assert id="CSIP7" role="ERROR" test="@CREATEDATE">The metsHdr element MUST have a CREATEDATE attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP8" REQLEVEL="SHOULD" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Package last modification datetime</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@LASTMODDATE` records the data and time the package was modified and is mandatory when the package has been modified.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/@LASTMODDATE</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST8-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/@LASTMODDATE</testString>
+                    </test>
+                    <test ID="TEST8-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr">
+                                    <iso:assert id="CSIP8" role="WARN" test="@LASTMODDATE">The metsHdr element SHOULD have a LASTMODDATE attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP9" REQLEVEL="MUST" RELATEDMAT="VocabularyOAISPackageType" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>OAIS Package type information</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">`mets/metsHdr/@csip:OAISPACKAGETYPE` is an additional CSIP attribute that declares the type of the IP.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/@csip:OAISPACKAGETYPE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST9-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/@csip:OAISPACKAGETYPE</testString>
+                    </test>
+                    <test ID="TEST9-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr">
+                                    <iso:assert id="CSIP9" role="ERROR" test="@csip:OAISPACKAGETYPE">The metsHdr element MUST have a csip:OAISPACKAGETYPE attribute.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP10" REQLEVEL="MUST">
                 <description>
                     <head>Agent</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">A mandatory agent element records the software used to create the package. Other uses of agents may be described in any local implementations that extend the profile.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/agent</dd>
-                        <dt>Cardinality</dt><dd>1..n</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST10-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/mets:agent</testString>
+                    </test>
+                    <test ID="TEST10-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr">
+                                    <iso:assert id="CSIP10" role="MUST" test="mets:agent">The metsHdr element MUST contain an agent element that records the software used to create the package.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
-           <requirement ID="CSIP11" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
+            <requirement ID="CSIP11" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Agent role</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent element MUST have a `@ROLE` attribute with the value “CREATOR”.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@ROLE='CREATOR']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST11-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/mets:agent[@ROLE='CREATOR']</testString>
+                    </test>
+                    <test ID="TEST11-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr/mets:agent">
+                                    <iso:assert id="CSIP11" role="ERROR" test="@ROLE = 'CREATOR'">The agent element MUST have a ROLE attribute with the value "CREATOR".</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP12" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Agent type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent element MUST have a `@TYPE` attribute with the value “OTHER”.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@TYPE='OTHER']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST12-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/mets:agent[@TYPE='OTHER']</testString>
+                    </test>
+                    <test ID="TEST12-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/merts:metsHdr/mets:agent">
+                                    <iso:assert id="CSIP12" role="ERROR" test="@TYPE = 'OTHER'">The agent element MUST have a TYPE attribute with the value "OTHER".</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP13" REQLEVEL="MUST" RELATEDMAT="VocabularyAgentOtherType" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Agent other type</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent element MUST have a `@OTHERTYPE` attribute with the value “SOFTWARE”.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/agent[@OTHERTYPE='SOFTWARE']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST13-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/mets:agent[@OTHERTYPE='SOFTWARE']</testString>
+                    </test>
+                    <test ID="TEST13-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr/mets:agent">
+                                    <iso:assert id="CSIP13" role="ERROR" test="@OTHERTYPE = 'SOFTWARE'">The agent element MUST have a OTHERTYPE attribute with the value "SOFTWARE".</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP14" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Agent name</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent's name element records the name of the software tool used to create the IP.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/agent/name</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST14-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/mets:agent/mets:name</testString>
+                    </test>
+                    <test ID="TEST14-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr/mets:agent">
+                                    <iso:assert id="CSIP14" role="ERROR" test="mets:name">The agent element MUST have a child name element that records the name of the software tool used to create the IP.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP15" REQLEVEL="MUST" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Agent additional information</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent's note element records the version of the tool used to create the IP.</p>
-                     <dl xmlns="http://www.w3.org/1999/xhtml">
-                         <dt>METS XPath</dt><dd>mets/metsHdr/agent/note</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST15-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/mets:agent/mets:note</testString>
+                    </test>
+                    <test ID="TEST15-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr/mets:agent">
+                                    <iso:assert id="CSIP15" role="ERROR" test="mets:note">The agent element MUST have a child note element that records the version of the tool used to create the IP.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP16" REQLEVEL="MUST" RELATEDMAT="VocabularyNoteType" EXAMPLES="metsHdrElementExample1">
                 <description>
                     <head>Classification of the agent additional information</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The mandatory agent element's note child has a `@csip:NOTETYPE` attribute with a fixed value of "SOFTWARE VERSION".</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/metsHdr/agent/note[@csip:NOTETYPE='SOFTWARE VERSION']</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST16-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/mets:metsHdr/mets:agent/mets:note[@csip:NOTETYPE='SOFTWARE VERSION']</testString>
+                    </test>
+                    <test ID="TEST16-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets/mets:metsHdr/mets:agent">
+                                    <iso:assert id="CSIP16" role="ERROR" test="mets:note[@csip:NOTETYPE = 'SOFTWARE VERSION']">The mandatory agent element’s note child has a @csip:NOTETYPE attribute with a fixed value of “SOFTWARE VERSION”.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
         </metsHdr>
         <dmdSec ID="dmdSecElement">

--- a/profile/E-ARK-CSIP-v2-1-1.xml
+++ b/profile/E-ARK-CSIP-v2-1-1.xml
@@ -159,18 +159,14 @@
                 </description>
                 <tests>
                     <test ID="TEST1-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
-                        <testWrap>
-                            <!--as far as my understanding goes, this XPATH wouldn't evaluate correctly in practice without the mets namespace prefix, though I could certainly be incorrect and it might need to be pruned in the interpolation to the published PDF-->
-                            <testXML>mets/@OBJID</testXML>
-                        </testWrap>
+                        <testString>/mets:mets/@OBJID</testString>
                     </test>
                     <test ID="TEST1-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
                         <testWrap>
                             <testXML>
                                 <iso:rule context="/mets:mets">
-                                    <!--the schematron test expressed in the python validator goes simply @OBJID, of course being the root element a count of one is implied but to make it implicit in the test I have modified to include a count, may require discussion-->
-                                    <!--NB precedent for this is the proposed interpolation of CSIP10, pyvalidator schematron tests plainly for mets:agent proposed profile test adds cardinality test-->
-                                    <iso:assert id="CSIP1" role="ERROR" test="count(@OBJID)=1">The mets/@OBJID attribute is mandatory, its value is a string identifier for the METS document. For the package METS document, this should be the name/ID of the package, i.e. the name of the package root folder. For a representation level METS document this value records the name/ID of the representation, i.e. the name of the top-level representation folder.</iso:assert>
+                                    <!--combination of assertion role and test evaluation to ascertain cardinality, error+attributeRef = 1..1, warn+attributeRef = 0..1 etc-->
+                                    <iso:assert id="CSIP1" role="ERROR" test="@OBJID">The mets/@OBJID attribute is mandatory, its value is a string identifier for the METS document. For the package METS document, this should be the name/ID of the package, i.e. the name of the package root folder. For a representation level METS document this value records the name/ID of the representation, i.e. the name of the top-level representation folder.</iso:assert>
                                 </iso:rule>
                             </testXML>
                         </testWrap>
@@ -184,16 +180,14 @@
                 </description>
                 <tests>
                     <test ID="TEST2-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
-                        <testWrap>
-                            <testXML>mets/@TYPE</testXML>
-                        </testWrap>
+                        <testString>/mets:mets/@TYPE</testString>
                     </test>
                     <test ID="TEST2-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
                         <testWrap>
                             <testXML>
                                 <iso:rule context="/mets:mets">
                                     <!--ignoring the issue raised with casing incogruity-->
-                                    <iso:assert id="CSIP2" role="ERROR" test="count(@TYPE)=1">The mets/@TYPE attibute MUST be used to declare the category of the content held in the package, e.g. book, journal, stereograph, video, etc.. Legal values are defined in a fixed vocabulary.</iso:assert>
+                                    <iso:assert id="CSIP2" role="ERROR" test="@TYPE">The mets/@TYPE attibute MUST be used to declare the category of the content held in the package, e.g. book, journal, stereograph, video, etc.. Legal values are defined in a fixed vocabulary.</iso:assert>
                                 </iso:rule>
                             </testXML>
                         </testWrap>
@@ -207,17 +201,15 @@
                 </description>
                 <tests>
                     <test ID="TEST3-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
-                        <testWrap>
-                            <!--case of the 'other' casing issue, as such I am leaving this alone for now-->
-                            <testXML>mets[@TYPE='OTHER']/@csip:OTHERTYPE</testXML>
-                        </testWrap>
+                        <!--case of the 'other' casing issue, as such I am leaving this alone for now-->
+                        <testString>/mets:mets[@TYPE='OTHER']/@csip:OTHERTYPE</testString>
                     </test>
                     <test ID="TEST3-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
                         <testWrap>
                             <testXML>
                                 <iso:rule context="">
-                                    <!--I have made cardinality implicit in this test (modified from pyvalidator), but it could be confusing because of the 'should conditional must' situation. It's probably best to discuss this-->
-                                    <iso:assert id="CSIP3" role="WARN" test="(@TYPE = 'OTHER' and count(@csip:OTHERTYPE)=1) or @TYPE != 'OTHER'">When the content category used falls outside of the defined vocabulary the mets/@TYPE value must be set to “OTHER” and the specific value declared in mets/@csip:OTHERTYPE. The vocabulary will develop under the curation of the DILCIS Board as additional content information type specifications are produced.</iso:assert>
+                                    <!--'should conditional must' situation-->
+                                    <iso:assert id="CSIP3" role="WARN" test="(@TYPE = 'OTHER' and @csip:OTHERTYPE) or @TYPE != 'OTHER'">When the content category used falls outside of the defined vocabulary the mets/@TYPE value must be set to “OTHER” and the specific value declared in mets/@csip:OTHERTYPE. The vocabulary will develop under the curation of the DILCIS Board as additional content information type specifications are produced.</iso:assert>
                                 </iso:rule>
                             </testXML>
                         </testWrap>
@@ -225,21 +217,20 @@
                 </tests>
             </requirement>
             <requirement ID="CSIP4" REQLEVEL="SHOULD" RELATEDMAT="VocabularyContentInformationTypeSpecification" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
+               <!--metsRootElementExample1 (listed as an example) does not appear to be relevant to these tests-->
                <description>
                     <head>Content Information Type Specification</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">Used to declare the Content Information Type Specification used when creating the package. Legal values are defined in a fixed vocabulary. The attribute is mandatory for representation level METS documents. The vocabulary will evolve under the care of the DILCIS Board as additional Content Information Type Specifications are developed.</p>
                 </description>
                 <tests>
                     <test ID="TEST4-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
-                        <testWrap>
-                            <testXML>mets/@csip:CONTENTINFORMATIONTYPE</testXML>
-                        </testWrap>
+                        <testString>/mets:mets/@csip:CONTENTINFORMATIONTYPE</testString>
                     </test>
                     <test ID="TEST4-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
                         <testWrap>
                             <testXML>
                                 <iso:rule context="/mets:mets">
-                                    <iso:assert id="CSIP4" role="WARN" test="count(@csip:CONTENTINFORMATIONTYPE)<=1">Used to declare the Content Information Type Specification used when creating the package. Legal values are defined in a fixed vocabulary. The attribute is mandatory for representation level METS documents.</iso:assert>
+                                    <iso:assert id="CSIP4" role="WARN" test="@csip:CONTENTINFORMATIONTYPE">Used to declare the Content Information Type Specification used when creating the package. Legal values are defined in a fixed vocabulary. The attribute is mandatory for representation level METS documents.</iso:assert>
                                 </iso:rule>
                             </testXML>
                         </testWrap>
@@ -250,21 +241,42 @@
                 <description>
                     <head>Other Content Information Type Specification</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">When the `mets/@csip:CONTENTINFORMATIONTYPE` has the value "OTHER" the `mets/@csip:OTHERCONTENTINFORMATIONTYPE` must state the content information type.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets[@csip:CONTENTINFORMATIONTYPE='OTHER']/@csip:OTHERCONTENTINFORMATIONTYPE</dd>
-                        <dt>Cardinality</dt><dd>0..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST5-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets[@csip:CONTENTINFORMATIONTYPE='OTHER']/@csip:OTHERCONTENTINFORMATIONTYPE</testString>
+                    </test>
+                    <test ID="TEST5-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <!--subject to 'other' casing issue-->
+                                    <iso:assert id="CSIP5" role="ERROR" test="(@csip:CONTENTINFORMATIONTYPE = 'OTHER' and @csip:OTHERCONTENTINFORMATIONTYPE) or @csip:CONTENTINFORMATIONTYPE != 'OTHER'">When the mets/@csip:CONTENTINFORMATIONTYPE has the value “OTHER” the mets/@csip:OTHERCONTENTINFORMATIONTYPE must state the content information type.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
             <requirement ID="CSIP6" REQLEVEL="MUST" EXAMPLES="metsRootElementExample1 metsRootElementExample2">
                 <description>
                     <head>METS Profile</head>
                     <p xmlns="http://www.w3.org/1999/xhtml">The URL of the METS profile that the information package conforms with.</p>
-                    <dl xmlns="http://www.w3.org/1999/xhtml">
-                        <dt>METS XPath</dt><dd>mets/@PROFILE</dd>
-                        <dt>Cardinality</dt><dd>1..1</dd>
-                    </dl>
                 </description>
+                <tests>
+                    <test ID="TEST6-1" TESTLANGUAGE="XPath" TESTLANGUAGEVERSION="3.1">
+                        <testString>/mets:mets/@PROFILE</testString>
+                    </test>
+                    <test ID="TEST6-2" TESTLANGUAGE="Schematron" TESTLANGUAGEVERSION="ISO" TESTLANGUAGEURI="http://purl.oclc.org/dsdl/schematron">
+                        <testWrap>
+                            <testXML>
+                                <iso:rule context="/mets:mets">
+                                    <iso:assert id="CSIP6" role="ERROR" test="@PROFILE">The PROFILE attribute MUST contain the URL of the METS profile that the information package conforms with.</iso:assert>
+                                </iso:rule>
+                            </testXML>
+                        </testWrap>
+                    </test>
+                </tests>
             </requirement>
         </metsRootElement>
         <metsHdr ID="metsHeaderElement">


### PR DESCRIPTION
New file created for updated CSIP METS profile, patch version incremented. CSIPs 1-4 updated to the proposed structure.
Comments throughout on various issues, some key notes:

- I have used the schematron tests from the pyvalidator repo, but I am implementing implicit cardinality wherever it is not enforced
- I am directly using the existing XPATHs from the current profile, while ensuring their validity, so the XPATH tests are not comprehensive 
- CSIPs 2-4 reference fixed vocabularies, per discussion I am not implementing the vocabularies in the respective tests. 