### PR TITLE
Fix/reanme of cits to cs

### DIFF
--- a/specification/implementation/metadata/mets/dmdsec/index.md
+++ b/specification/implementation/metadata/mets/dmdsec/index.md
@@ -2,6 +2,6 @@
 
 The purpose of the METS descriptive metadata section is to embed or refer to files containing descriptive metadata. CSIP is only using referencing of files containing descriptive metadata.
 
-The CSIP does not prescribe or assume the use of specific descriptive metadata schemas. This means implementers are free to use descriptive metadata  standards of their choosing inside a CSIP package following the recommendations in the "E-ARK Content Information Type Specification for Archival Information" (CITS Archival Information) found at <https://citsarchival.dilcis.eu/specification/> . 
+The CSIP does not prescribe or assume the use of specific descriptive metadata schemas. This means implementers are free to use descriptive metadata  standards of their choosing inside a CSIP package following the recommendations in the "E-ARK Conmmon Specification for Archival Information" (CS Archival Information) found at <https://citsarchival.dilcis.eu/specification/> . 
 
 Specific elements for which the exact use is fixed within this specification are highlighted in the following table.

--- a/specification/implementation/metadata/premis/index.md
+++ b/specification/implementation/metadata/premis/index.md
@@ -1,4 +1,4 @@
 ## Use of PREMIS
-The CSIP recommends and advocates the use of the PREservation Metadata Implementation Strategies (PREMIS, <https://www.loc.gov/standards/premis/>) metadata standard for recording preservation and technical metadata about digital objects contained within CSIP Information Packages. The use of PREMIS is described in the "E-ARK Content Information Type Specification for Preservation Metadata using PREMIS" (CITS PREMIS) found at <https://citspremis.dilcis.eu/specification/> . 
+The CSIP recommends and advocates the use of the PREservation Metadata Implementation Strategies (PREMIS, <https://www.loc.gov/standards/premis/>) metadata standard for recording preservation and technical metadata about digital objects contained within CSIP Information Packages. The use of PREMIS is described in the "E-ARK Common Specification for Preservation Metadata using PREMIS" (CS PREMIS) found at <https://citspremis.dilcis.eu/specification/> . 
 
 Note that use of PREMIS is not mandatory.


### PR DESCRIPTION
CITS PREMIS and Archival have been renamed to CS PREMIS and Archival. This is the textual update following that change.